### PR TITLE
changes to pick up correct ruby version

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -26,9 +26,6 @@ esac
 
 fi
 
-
-
-
 # PATH needs CR
 # Avoid depending upon Character Ranges.
 as_cr_letters='abcdefghijklmnopqrstuvwxyz'
@@ -6375,23 +6372,22 @@ librubyarg=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG[
 if test -f "$rubyhdrdir/$librubyarg"; then
   librubyarg="$rubyhdrdir/$librubyarg"
 else
-
   rubylibdir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["libdir"])'`
-  if test "X$RUBY_PATH" != "X"; then
-    librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, '') << %' -L#{Config.expand(Config::CONFIG[\"libdir\"])}'"`
-  elif test "$RUBY_PATH" == "/usr/bin"; then
+ if test "$RUBY_PATH" == "/usr/bin"; then
     if test -d "/System/Library/Frameworks/Ruby.framework"; then
-                    RUBY_LIBS="-framework Ruby"
-                    RUBY_CFLAGS=
+      RUBY_LIBS="-framework Ruby"
+      RUBY_CFLAGS=
       librubyarg=
     elif test -f "$rubylibdir/$librubyarg"; then
       librubyarg="$rubylibdir/$librubyarg"
     elif test "$librubyarg" = "libruby.a"; then
-                    librubyarg="-lruby"
+      librubyarg="-lruby"
     else
       librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, '') << %' -L#{Config.expand(Config::CONFIG[\"libdir\"])}'"`
     fi
-  fi
+  elif test "X$RUBY_PATH" != "X"; then
+    librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, '') << %' -L#{Config.expand(Config::CONFIG[\"libdir\"])}'"`
+  fi 
 fi
 
 if test "X$librubyarg" != "X"; then

--- a/src/configure
+++ b/src/configure
@@ -717,6 +717,7 @@ TCL_PRO
 TCL_CFLAGS
 TCL_LIBS
 vi_cv_path_ruby
+with_custom_ruby
 RUBY_SRC
 RUBY_OBJ
 RUBY_PRO

--- a/src/configure
+++ b/src/configure
@@ -716,8 +716,8 @@ TCL_OBJ
 TCL_PRO
 TCL_CFLAGS
 TCL_LIBS
-vi_cv_path_ruby
 with_custom_ruby
+vi_cv_path_ruby
 RUBY_SRC
 RUBY_OBJ
 RUBY_PRO
@@ -1350,10 +1350,10 @@ Optional Features:
   --enable-luainterp=OPTS     Include Lua interpreter.  default=no OPTS=no/yes/dynamic
   --enable-mzschemeinterp   Include MzScheme interpreter.
   --enable-perlinterp=OPTS     Include Perl interpreter.  default=no OPTS=no/yes/dynamic
-  --enable-pythoninterp   Include Python interpreter.
-  --enable-python3interp   Include Python3 interpreter.
+  --enable-pythoninterp=OPTS   Include Python interpreter. default=no OPTS=no/yes/dynamic
+  --enable-python3interp=OPTS   Include Python3 interpreter. default=no OPTS=no/yes/dynamic
   --enable-tclinterp      Include Tcl interpreter.
-  --enable-rubyinterp     Include Ruby interpreter.
+  --enable-rubyinterp=OPTS     Include Ruby interpreter.  default=no OPTS=no/yes/dynamic
   --enable-cscope         Include cscope interface.
   --enable-workshop       Include Sun Visual Workshop support.
   --disable-netbeans      Disable NetBeans integration support.
@@ -5263,7 +5263,7 @@ fi
 
 { echo "$as_me:$LINENO: result: $enable_pythoninterp" >&5
 echo "${ECHO_T}$enable_pythoninterp" >&6; }
-if test "$enable_pythoninterp" = "yes"; then
+if test "$enable_pythoninterp" = "yes" -o "$enable_pythoninterp" = "dynamic"; then
     # Extract the first word of "python", so it can be a program name with args.
 set dummy python; ac_word=$2
 { echo "$as_me:$LINENO: checking for $ac_word" >&5
@@ -5613,7 +5613,7 @@ fi
 
 { echo "$as_me:$LINENO: result: $enable_python3interp" >&5
 echo "${ECHO_T}$enable_python3interp" >&6; }
-if test "$enable_python3interp" = "yes"; then
+if test "$enable_python3interp" = "yes" -o "$enable_python3interp" = "dynamic"; then
     # Extract the first word of "python3", so it can be a program name with args.
 set dummy python3; ac_word=$2
 { echo "$as_me:$LINENO: checking for $ac_word" >&5
@@ -5843,8 +5843,8 @@ rm -f core conftest.err conftest.$ac_objext conftest_ipa8_conftest.oo \
 echo "${ECHO_T}no" >&6; }
       fi
 
-                  { echo "$as_me:$LINENO: checking if compile and link flags for Python are sane" >&5
-echo $ECHO_N "checking if compile and link flags for Python are sane... $ECHO_C" >&6; }
+                  { echo "$as_me:$LINENO: checking if compile and link flags for Python 3 are sane" >&5
+echo $ECHO_N "checking if compile and link flags for Python 3 are sane... $ECHO_C" >&6; }
       cflags_save=$CFLAGS
       libs_save=$LIBS
       CFLAGS="$CFLAGS $PYTHON3_CFLAGS"
@@ -5927,10 +5927,115 @@ _ACEOF
 #define DYNAMIC_PYTHON3 1
 _ACEOF
 
+  { echo "$as_me:$LINENO: checking whether we can do without RTLD_GLOBAL" >&5
+echo $ECHO_N "checking whether we can do without RTLD_GLOBAL... $ECHO_C" >&6; }
+  cflags_save=$CFLAGS
+  CFLAGS="$CFLAGS $PYTHON3_CFLAGS"
+  ldflags_save=$LDFLAGS
+  LDFLAGS="$LDFLAGS -ldl"
+  if test "$cross_compiling" = yes; then
+  { { echo "$as_me:$LINENO: error: cannot run test program while cross compiling
+See \`config.log' for more details." >&5
+echo "$as_me: error: cannot run test program while cross compiling
+See \`config.log' for more details." >&2;}
+   { (exit 1); exit 1; }; }
+else
+  cat >conftest.$ac_ext <<_ACEOF
+
+    #include <dlfcn.h>
+    /* If this program fails, then RTLD_GLOBAL is needed.
+     * RTLD_GLOBAL will be used and then it is not possible to
+     * have both python versions enabled in the same vim instance.
+     * Only the first pyhton version used will be switched on.
+     */
+
+    int no_rtl_global_needed_for(char *python_instsoname)
+    {
+      int needed = 0;
+      void* pylib = dlopen(python_instsoname, RTLD_LAZY);
+      if (pylib != 0)
+      {
+          void (*init)(void) = dlsym(pylib, "Py_Initialize");
+          int (*simple)(char*) = dlsym(pylib, "PyRun_SimpleString");
+          void (*final)(void) = dlsym(pylib, "Py_Finalize");
+          (*init)();
+          needed = (*simple)("import termios") == -1;
+          (*final)();
+          dlclose(pylib);
+      }
+      return !needed;
+    }
+
+    int main(int argc, char** argv)
+    {
+      int not_needed = 0;
+      if (no_rtl_global_needed_for("libpython2.7.so.1.0") && no_rtl_global_needed_for("libpython3.1.so.1.0"))
+            not_needed = 1;
+      return !not_needed;
+    }
+_ACEOF
+rm -f conftest$ac_exeext
+if { (ac_try="$ac_link"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval "echo \"\$as_me:$LINENO: $ac_try_echo\"") >&5
+  (eval "$ac_link") 2>&5
+  ac_status=$?
+  echo "$as_me:$LINENO: \$? = $ac_status" >&5
+  (exit $ac_status); } && { ac_try='./conftest$ac_exeext'
+  { (case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval "echo \"\$as_me:$LINENO: $ac_try_echo\"") >&5
+  (eval "$ac_try") 2>&5
+  ac_status=$?
+  echo "$as_me:$LINENO: \$? = $ac_status" >&5
+  (exit $ac_status); }; }; then
+  { echo "$as_me:$LINENO: result: yes" >&5
+echo "${ECHO_T}yes" >&6; };cat >>confdefs.h <<\_ACEOF
+#define PY_NO_RTLD_GLOBAL 1
+_ACEOF
+
+else
+  echo "$as_me: program exited with status $ac_status" >&5
+echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+( exit $ac_status )
+{ echo "$as_me:$LINENO: result: no" >&5
+echo "${ECHO_T}no" >&6; }
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext conftest.$ac_objext conftest.$ac_ext
+fi
+
+
+  CFLAGS=$cflags_save
+  LDFLAGS=$ldflags_save
   PYTHON_SRC="if_python.c"
   PYTHON_OBJ="objects/if_python.o"
   PYTHON_CFLAGS="$PYTHON_CFLAGS -DDYNAMIC_PYTHON_DLL=\\\"${python_INSTSONAME}\\\""
   PYTHON_LIBS=
+  PYTHON3_SRC="if_python3.c"
+  PYTHON3_OBJ="objects/if_python3.o"
+  PYTHON3_CFLAGS="$PYTHON3_CFLAGS -DDYNAMIC_PYTHON3_DLL=\\\"${python3_INSTSONAME}\\\""
+  PYTHON3_LIBS=
+elif test "$python_ok" = yes && test "$enable_pythoninterp" = "dynamic"; then
+  cat >>confdefs.h <<\_ACEOF
+#define DYNAMIC_PYTHON 1
+_ACEOF
+
+  PYTHON_SRC="if_python.c"
+  PYTHON_OBJ="objects/if_python.o"
+  PYTHON_CFLAGS="$PYTHON_CFLAGS -DDYNAMIC_PYTHON_DLL=\\\"${python_INSTSONAME}\\\""
+  PYTHON_LIBS=
+elif test "$python3_ok" = yes && test "$enable_python3interp" = "dynamic"; then
+  cat >>confdefs.h <<\_ACEOF
+#define DYNAMIC_PYTHON3 1
+_ACEOF
+
   PYTHON3_SRC="if_python3.c"
   PYTHON3_OBJ="objects/if_python3.o"
   PYTHON3_CFLAGS="$PYTHON3_CFLAGS -DDYNAMIC_PYTHON3_DLL=\\\"${python3_INSTSONAME}\\\""
@@ -6275,6 +6380,10 @@ echo "${ECHO_T}too old; need Tcl version 8.0 or later" >&6; }
 fi
 
 
+
+
+
+
 { echo "$as_me:$LINENO: checking --enable-rubyinterp argument" >&5
 echo $ECHO_N "checking --enable-rubyinterp argument... $ECHO_C" >&6; }
 # Check whether --enable-rubyinterp was given.
@@ -6285,32 +6394,29 @@ else
 fi
 
 { echo "$as_me:$LINENO: result: $enable_rubyinterp" >&5
-  echo "${ECHO_T}$enable_rubyinterp" >&6; }
+echo "${ECHO_T}$enable_rubyinterp" >&6; }
 
-if test "$enable_rubyinterp" = "yes"; then
+if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
   { echo "$as_me:$LINENO: checking --with-ruby-command argument" >&5
-    echo $ECHO_N "checking --with-ruby-command argument... $ECHO_C" >&6; }
+echo $ECHO_N "checking --with-ruby-command argument... $ECHO_C" >&6; }
 
 # Check whether --with-ruby-command was given.
 if test "${with_ruby_command+set}" = set; then
-  withval=$with_ruby_command; RUBY_CMD="$withval" 
-  with_custom_ruby="true"
-  vi_cv_path_ruby="$withval"
-  { echo "$as_me:$LINENO: result: $RUBY_CMD" >&5
-    echo "${ECHO_T}$RUBY_CMD" >&6; }
+  withval=$with_ruby_command;  RUBY_CMD="$withval"; with_custom_ruby="true"; vi_cv_path_ruby="$withval"; { echo "$as_me:$LINENO: result: $RUBY_CMD" >&5
+echo "${ECHO_T}$RUBY_CMD" >&6; }
 else
-  with_custom_ruby="false"
-  RUBY_CMD="/usr/bin/ruby" 
-  vi_cv_path_ruby="/usr/bin/ruby"
-  { echo "$as_me:$LINENO: result: defaulting to $RUBY_CMD" >&5
-    echo "${ECHO_T}defaulting to $RUBY_CMD" >&6; }
+   RUBY_CMD="/usr/bin/ruby"; with_custom_ruby="false"; vi_cv_path_ruby="/usr/bin/ruby"; { echo "$as_me:$LINENO: result: defaulting to $RUBY_CMD" >&5
+echo "${ECHO_T}defaulting to $RUBY_CMD" >&6; }
 fi
 
-# Extract the first word of "$RUBY_CMD", so it can be a program name with args.
+
+
+
+
+  # Extract the first word of "$RUBY_CMD", so it can be a program name with args.
 set dummy $RUBY_CMD; ac_word=$2
 { echo "$as_me:$LINENO: checking for $ac_word" >&5
-  echo $ECHO_N "checking for $ac_word... $ECHO_C" >&6; }
-
+echo $ECHO_N "checking for $ac_word... $ECHO_C" >&6; }
 if test "${ac_cv_path_vi_cv_path_ruby+set}" = set; then
   echo $ECHO_N "(cached) $ECHO_C" >&6
 else
@@ -6338,97 +6444,108 @@ IFS=$as_save_IFS
 esac
 fi
 vi_cv_path_ruby=$ac_cv_path_vi_cv_path_ruby
-
 if test -n "$vi_cv_path_ruby"; then
   { echo "$as_me:$LINENO: result: $vi_cv_path_ruby" >&5
-    echo "${ECHO_T}$vi_cv_path_ruby" >&6; }
+echo "${ECHO_T}$vi_cv_path_ruby" >&6; }
 else
   { echo "$as_me:$LINENO: result: no" >&5
-    echo "${ECHO_T}no" >&6; }
+echo "${ECHO_T}no" >&6; }
 fi
 
-if test "X$vi_cv_path_ruby" != "X"; then
+
+
+  if test "X$vi_cv_path_ruby" != "X"; then
     { echo "$as_me:$LINENO: checking Ruby version" >&5
-      echo $ECHO_N "checking Ruby version... $ECHO_C" >&6; }
-
+echo $ECHO_N "checking Ruby version... $ECHO_C" >&6; }
     if $vi_cv_path_ruby -e '(VERSION rescue RUBY_VERSION) >= "1.6.0" or exit 1' >/dev/null 2>/dev/null; then
-      # ruby version OK
       { echo "$as_me:$LINENO: result: OK" >&5
-        echo "${ECHO_T}OK" >&6; }
-      
-          rubyhdrdir=`$vi_cv_path_ruby -r mkmf -e 'print Config::CONFIG["rubyhdrdir"] || Config::CONFIG["archdir"] || $hdrdir' 2>/dev/null`
+echo "${ECHO_T}OK" >&6; }
+      { echo "$as_me:$LINENO: checking Ruby header files" >&5
+echo $ECHO_N "checking Ruby header files... $ECHO_C" >&6; }
+      rubyhdrdir=`$vi_cv_path_ruby -r mkmf -e 'print Config::CONFIG["rubyhdrdir"] || Config::CONFIG["archdir"] || $hdrdir' 2>/dev/null`
+      if test "X$rubyhdrdir" != "X"; then
+        { echo "$as_me:$LINENO: result: $rubyhdrdir" >&5
+echo "${ECHO_T}$rubyhdrdir" >&6; }
 
-          if test "X$rubyhdrdir" != "X"; then
-            { echo "$as_me:$LINENO: result: $rubyhdrdir" >&5
-              echo "${ECHO_T}$rubyhdrdir" >&6; }
+        RUBY_CFLAGS="-I$rubyhdrdir"
+        rubyarch=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["arch"]'`
 
-            RUBY_CFLAGS="-I$rubyhdrdir"
-            rubyarch=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["arch"]'`
-          
-            if test -d "$rubyhdrdir/$rubyarch"; then
-              RUBY_CFLAGS="$RUBY_CFLAGS -I$rubyhdrdir/$rubyarch"
-            fi
+        if test -d "$rubyhdrdir/$rubyarch"; then
+          RUBY_CFLAGS="$RUBY_CFLAGS -I$rubyhdrdir/$rubyarch"
+        fi
 
-            rubyversion=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["ruby_version"].gsub(/\./, "")[0,2]'`
-          
-            RUBY_CFLAGS="$RUBY_CFLAGS -DRUBY_VERSION=$rubyversion"
-            rubylibs=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LIBS"]'`
-          
-            if test "X$rubylibs" != "X"; then
-              RUBY_LIBS="$rubylibs"
-            fi
+        rubyversion=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["ruby_version"].gsub(/\./, "")[0,2]'`
+        RUBY_CFLAGS="$RUBY_CFLAGS -DRUBY_VERSION=$rubyversion"
+        rubylibs=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LIBS"]'`
 
-            librubyarg=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["LIBRUBYARG"])'`
-            librubystatic=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["LIBRUBY_A"])'`
-            librubydir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["libdir"])'`
+        if test "X$rubylibs" != "X"; then
+          RUBY_LIBS="$rubylibs"
+        fi
 
-            if test "$with_custom_ruby" == "false"; then
-              RUBY_LIBS="-framework Ruby"
-              RUBY_CFLAGS=
-              librubyarg=
-            else
-              if test -f "$librubydir/$librubystatic"; then
-                librubyarg="$librubyarg"
-                RUBY_LIBS="-L$librubydir"
-              elif test "$librubyarg" = "libruby.a"; then
-                librubyarg="-lruby"
-                RUBY_LIBS="-L$librubydir"
-              fi
-            fi
+        librubyarg=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["LIBRUBYARG"])'`
+        librubystatic=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["LIBRUBY_A"])'`
+        librubydir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["libdir"])'`
 
-            if test "X$librubyarg" != "X"; then
-              RUBY_LIBS="$librubyarg $RUBY_LIBS"
-            fi
-          
-            rubyldflags=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LDFLAGS"]'`
+        if test "$with_custom_ruby" == "false"; then
+          if test -d "/System/Library/Frameworks/Ruby.framework"; then
+                        RUBY_LIBS="-framework Ruby"
+                        RUBY_CFLAGS=
+            librubyarg=
+          elif test -f "$librubydir/$librubystatic"; then
+            librubyarg="$librubyarg"
+            RUBY_LIBS="-L$librubydir"
+          elif test "$librubyarg" = "libruby.a"; then
+            librubyarg="-lruby"
+            RUBY_LIBS="-L$librubydir"
+          fi
+        else
+          if test -f "$librubydir/$librubystatic"; then
+            librubyarg="$librubyarg"
+            RUBY_LIBS="-L$librubydir"
+          elif test "$librubyarg" = "libruby.a"; then
+            librubyarg="-lruby"
+            RUBY_LIBS="-L$librubydir"
+          fi
+        fi
 
-            if test "X$rubyldflags" != "X"; then
-              rubyldflags=`echo "$rubyldflags" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
-              if test "X$rubyldflags" != "X"; then
-                LDFLAGS="$rubyldflags $LDFLAGS"
-              fi
-            fi
-            if test "X$rubyldflags" != "X"; then
-              LDFLAGS="$rubyldflags $LDFLAGS"
-            fi
- 
+        if test "X$librubyarg" != "X"; then
+          RUBY_LIBS="$librubyarg $RUBY_LIBS"
+        fi
+
+        rubyldflags=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LDFLAGS"]'`
+
+        if test "X$rubyldflags" != "X"; then
+                                        rubyldflags=`echo "$rubyldflags" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
+          if test "X$rubyldflags" != "X"; then
+            LDFLAGS="$rubyldflags $LDFLAGS"
+          fi
+        fi
+
+        if test "X$rubyldflags" != "X"; then
+          LDFLAGS="$rubyldflags $LDFLAGS"
+        fi
+
         RUBY_SRC="if_ruby.c"
         RUBY_OBJ="objects/if_ruby.o"
         RUBY_PRO="if_ruby.pro"
 
-cat >>confdefs.h <<\_ACEOF
+        cat >>confdefs.h <<\_ACEOF
 #define FEAT_RUBY 1
 _ACEOF
+
+
+
       else
         { echo "$as_me:$LINENO: result: not found; disabling Ruby" >&5
-          echo "${ECHO_T}not found; disabling Ruby" >&6; }
+echo "${ECHO_T}not found; disabling Ruby" >&6; }
       fi
     else
       { echo "$as_me:$LINENO: result: too old; need Ruby version 1.6.0 or later" >&5
-        echo "${ECHO_T}too old; need Ruby version 1.6.0 or later" >&6; }
+echo "${ECHO_T}too old; need Ruby version 1.6.0 or later" >&6; }
     fi
   fi
 fi
+
 
 
 
@@ -19951,6 +20068,7 @@ TCL_OBJ!$TCL_OBJ$ac_delim
 TCL_PRO!$TCL_PRO$ac_delim
 TCL_CFLAGS!$TCL_CFLAGS$ac_delim
 TCL_LIBS!$TCL_LIBS$ac_delim
+with_custom_ruby!$with_custom_ruby$ac_delim
 vi_cv_path_ruby!$vi_cv_path_ruby$ac_delim
 RUBY_SRC!$RUBY_SRC$ac_delim
 RUBY_OBJ!$RUBY_OBJ$ac_delim
@@ -19996,7 +20114,7 @@ LIBOBJS!$LIBOBJS$ac_delim
 LTLIBOBJS!$LTLIBOBJS$ac_delim
 _ACEOF
 
-  if test `sed -n "s/.*$ac_delim\$/X/p" conf$$subs.sed | grep -c X` = 49; then
+  if test `sed -n "s/.*$ac_delim\$/X/p" conf$$subs.sed | grep -c X` = 50; then
     break
   elif $ac_last_try; then
     { { echo "$as_me:$LINENO: error: could not make $CONFIG_STATUS" >&5

--- a/src/configure
+++ b/src/configure
@@ -26,6 +26,9 @@ esac
 
 fi
 
+
+
+
 # PATH needs CR
 # Avoid depending upon Character Ranges.
 as_cr_letters='abcdefghijklmnopqrstuvwxyz'
@@ -6271,10 +6274,6 @@ echo "${ECHO_T}too old; need Tcl version 8.0 or later" >&6; }
 fi
 
 
-
-
-
-
 { echo "$as_me:$LINENO: checking --enable-rubyinterp argument" >&5
 echo $ECHO_N "checking --enable-rubyinterp argument... $ECHO_C" >&6; }
 # Check whether --enable-rubyinterp was given.
@@ -6285,24 +6284,32 @@ else
 fi
 
 { echo "$as_me:$LINENO: result: $enable_rubyinterp" >&5
-echo "${ECHO_T}$enable_rubyinterp" >&6; }
+  echo "${ECHO_T}$enable_rubyinterp" >&6; }
+
 if test "$enable_rubyinterp" = "yes"; then
   { echo "$as_me:$LINENO: checking --with-ruby-command argument" >&5
-echo $ECHO_N "checking --with-ruby-command argument... $ECHO_C" >&6; }
+    echo $ECHO_N "checking --with-ruby-command argument... $ECHO_C" >&6; }
 
 # Check whether --with-ruby-command was given.
 if test "${with_ruby_command+set}" = set; then
-  withval=$with_ruby_command; RUBY_PATH=`echo "$withval" | sed 's/\(.*\)\/\([^/]*\)$/\1/'`; RUBY_CMD=`echo "$withval" | sed 's/.*\/\([^/]*\)$/\1/'`; { echo "$as_me:$LINENO: result: $RUBY_CMD" >&5
-echo "${ECHO_T}$RUBY_CMD" >&6; }
+  withval=$with_ruby_command; RUBY_CMD="$withval" 
+  with_custom_ruby="true"
+  vi_cv_path_ruby="$withval"
+  { echo "$as_me:$LINENO: result: $RUBY_CMD" >&5
+    echo "${ECHO_T}$RUBY_CMD" >&6; }
 else
-  RUBY_CMD="ruby"; RUBY_PATH=`dirname \`which ruby\``; { echo "$as_me:$LINENO: result: defaulting to $RUBY_CMD" >&5
-echo "${ECHO_T}defaulting to $RUBY_CMD" >&6; }
+  with_custom_ruby="false"
+  RUBY_CMD="/usr/bin/ruby" 
+  vi_cv_path_ruby="/usr/bin/ruby"
+  { echo "$as_me:$LINENO: result: defaulting to $RUBY_CMD" >&5
+    echo "${ECHO_T}defaulting to $RUBY_CMD" >&6; }
 fi
 
-  # Extract the first word of "$RUBY_CMD", so it can be a program name with args.
+# Extract the first word of "$RUBY_CMD", so it can be a program name with args.
 set dummy $RUBY_CMD; ac_word=$2
 { echo "$as_me:$LINENO: checking for $ac_word" >&5
-echo $ECHO_N "checking for $ac_word... $ECHO_C" >&6; }
+  echo $ECHO_N "checking for $ac_word... $ECHO_C" >&6; }
+
 if test "${ac_cv_path_vi_cv_path_ruby+set}" = set; then
   echo $ECHO_N "(cached) $ECHO_C" >&6
 else
@@ -6312,7 +6319,7 @@ else
   ;;
   *)
   as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $RUBY_PATH
+for as_dir in $PATH
 do
   IFS=$as_save_IFS
   test -z "$as_dir" && as_dir=.
@@ -6326,101 +6333,106 @@ done
 done
 IFS=$as_save_IFS
 
-  test -z "$ac_cv_path_vi_cv_path_ruby" && ac_cv_path_vi_cv_path_ruby=""""
   ;;
 esac
 fi
 vi_cv_path_ruby=$ac_cv_path_vi_cv_path_ruby
+
 if test -n "$vi_cv_path_ruby"; then
   { echo "$as_me:$LINENO: result: $vi_cv_path_ruby" >&5
-echo "${ECHO_T}$vi_cv_path_ruby" >&6; }
+    echo "${ECHO_T}$vi_cv_path_ruby" >&6; }
 else
   { echo "$as_me:$LINENO: result: no" >&5
-echo "${ECHO_T}no" >&6; }
+    echo "${ECHO_T}no" >&6; }
 fi
 
-
-  if test "X$vi_cv_path_ruby" != "X"; then
+if test "X$vi_cv_path_ruby" != "X"; then
     { echo "$as_me:$LINENO: checking Ruby version" >&5
-echo $ECHO_N "checking Ruby version... $ECHO_C" >&6; }
+      echo $ECHO_N "checking Ruby version... $ECHO_C" >&6; }
+
     if $vi_cv_path_ruby -e '(VERSION rescue RUBY_VERSION) >= "1.6.0" or exit 1' >/dev/null 2>/dev/null; then
+      # ruby version OK
       { echo "$as_me:$LINENO: result: OK" >&5
-echo "${ECHO_T}OK" >&6; }
-      { echo "$as_me:$LINENO: checking Ruby header files" >&5
-echo $ECHO_N "checking Ruby header files... $ECHO_C" >&6; }
-      rubyhdrdir=`$vi_cv_path_ruby -r mkmf -e 'print Config::CONFIG["rubyhdrdir"] || Config::CONFIG["archdir"] || $hdrdir' 2>/dev/null`
-      if test "X$rubyhdrdir" != "X"; then
-	{ echo "$as_me:$LINENO: result: $rubyhdrdir" >&5
+        echo "${ECHO_T}OK" >&6; }
+      
+          rubyhdrdir=`$vi_cv_path_ruby -r mkmf -e 'print Config::CONFIG["rubyhdrdir"] || Config::CONFIG["archdir"] || $hdrdir' 2>/dev/null`
 
-echo "${ECHO_T}$rubyhdrdir" >&6; }
+          if test "X$rubyhdrdir" != "X"; then
+            { echo "$as_me:$LINENO: result: $rubyhdrdir" >&5
+              echo "${ECHO_T}$rubyhdrdir" >&6; }
 
-RUBY_CFLAGS="-I$rubyhdrdir"
-rubyarch=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["arch"]'`
-if test -d "$rubyhdrdir/$rubyarch"; then
-  RUBY_CFLAGS="$RUBY_CFLAGS -I$rubyhdrdir/$rubyarch"
-fi
+            RUBY_CFLAGS="-I$rubyhdrdir"
+            rubyarch=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["arch"]'`
+          
+            if test -d "$rubyhdrdir/$rubyarch"; then
+              RUBY_CFLAGS="$RUBY_CFLAGS -I$rubyhdrdir/$rubyarch"
+            fi
 
-rubyversion=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["ruby_version"].gsub(/\./, "")[0,2]'`
-RUBY_CFLAGS="$RUBY_CFLAGS -DRUBY_VERSION=$rubyversion"
-rubylibs=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LIBS"]'`
+            rubyversion=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["ruby_version"].gsub(/\./, "")[0,2]'`
+          
+            RUBY_CFLAGS="$RUBY_CFLAGS -DRUBY_VERSION=$rubyversion"
+            rubylibs=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LIBS"]'`
+          
+            if test "X$rubylibs" != "X"; then
+              RUBY_LIBS="$rubylibs"
+            fi
 
-if test "X$rubylibs" != "X"; then
-  RUBY_LIBS="$rubylibs"
-fi
+            librubyarg=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["LIBRUBYARG"])'`
+            librubystatic=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["LIBRUBY_A"])'`
+            librubydir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["libdir"])'`
 
-librubyarg=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["LIBRUBYARG"])'`
-if test -f "$rubyhdrdir/$librubyarg"; then
-  librubyarg="$rubyhdrdir/$librubyarg"
-else
-  rubylibdir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["libdir"])'`
- if test "$RUBY_PATH" == "/usr/bin"; then
-    if test -d "/System/Library/Frameworks/Ruby.framework"; then
-      RUBY_LIBS="-framework Ruby"
-      RUBY_CFLAGS=
-      librubyarg=
-    elif test -f "$rubylibdir/$librubyarg"; then
-      librubyarg="$rubylibdir/$librubyarg"
-    elif test "$librubyarg" = "libruby.a"; then
-      librubyarg="-lruby"
-    else
-      librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, '') << %' -L#{Config.expand(Config::CONFIG[\"libdir\"])}'"`
-    fi
-  elif test "X$RUBY_PATH" != "X"; then
-    librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, '') << %' -L#{Config.expand(Config::CONFIG[\"libdir\"])}'"`
-  fi 
-fi
+            if test "$with_custom_ruby" == "false"; then
+              RUBY_LIBS="-framework Ruby"
+              RUBY_CFLAGS=
+              librubyarg=
+            else
+              if test -f "$librubydir/$librubystatic"; then
+                librubyarg="$librubyarg"
+                RUBY_LIBS="-L$librubydir"
+              elif test "$librubyarg" = "libruby.a"; then
+                librubyarg="-lruby"
+                RUBY_LIBS="-L$librubydir"
+              fi
+            fi
 
-if test "X$librubyarg" != "X"; then
-  RUBY_LIBS="$librubyarg $RUBY_LIBS"
-fi
+            if test "X$librubyarg" != "X"; then
+              RUBY_LIBS="$librubyarg $RUBY_LIBS"
+            fi
+          
+            rubyldflags=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LDFLAGS"]'`
 
-rubyldflags=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LDFLAGS"]'`
-if test "x$MACOSX" = "xyes"; then
-                                rubyldflags=`echo "$rubyldflags" | sed -e 's/-arch[^-]*//g'`
-fi
-if test "X$rubyldflags" != "X"; then
-  LDFLAGS="$rubyldflags $LDFLAGS"
-fi
-
-RUBY_SRC="if_ruby.c"
-RUBY_OBJ="objects/if_ruby.o"
-RUBY_PRO="if_ruby.pro"
+            if test "X$rubyldflags" != "X"; then
+              rubyldflags=`echo "$rubyldflags" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
+              if test "X$rubyldflags" != "X"; then
+                LDFLAGS="$rubyldflags $LDFLAGS"
+              fi
+            fi
+            if test "X$rubyldflags" != "X"; then
+              LDFLAGS="$rubyldflags $LDFLAGS"
+            fi
+ 
+        RUBY_SRC="if_ruby.c"
+        RUBY_OBJ="objects/if_ruby.o"
+        RUBY_PRO="if_ruby.pro"
 
 cat >>confdefs.h <<\_ACEOF
-
 #define FEAT_RUBY 1
 _ACEOF
-
       else
-	{ echo "$as_me:$LINENO: result: not found; disabling Ruby" >&5
-echo "${ECHO_T}not found; disabling Ruby" >&6; }
+        { echo "$as_me:$LINENO: result: not found; disabling Ruby" >&5
+          echo "${ECHO_T}not found; disabling Ruby" >&6; }
       fi
     else
       { echo "$as_me:$LINENO: result: too old; need Ruby version 1.6.0 or later" >&5
-echo "${ECHO_T}too old; need Ruby version 1.6.0 or later" >&6; }
+        echo "${ECHO_T}too old; need Ruby version 1.6.0 or later" >&6; }
     fi
   fi
 fi
+
+
+
+
+
 
 { echo "$as_me:$LINENO: checking --enable-cscope argument" >&5
 echo $ECHO_N "checking --enable-cscope argument... $ECHO_C" >&6; }

--- a/src/configure
+++ b/src/configure
@@ -6295,10 +6295,10 @@ echo $ECHO_N "checking --with-ruby-command argument... $ECHO_C" >&6; }
 
 # Check whether --with-ruby-command was given.
 if test "${with_ruby_command+set}" = set; then
-  withval=$with_ruby_command; RUBY_CMD="$withval"; { echo "$as_me:$LINENO: result: $RUBY_CMD" >&5
+  withval=$with_ruby_command; RUBY_PATH=`echo "$withval" | sed 's/\(.*\)\/\([^/]*\)$/\1/'`; RUBY_CMD=`echo "$withval" | sed 's/.*\/\([^/]*\)$/\1/'`; { echo "$as_me:$LINENO: result: $RUBY_CMD" >&5
 echo "${ECHO_T}$RUBY_CMD" >&6; }
 else
-  RUBY_CMD="ruby"; { echo "$as_me:$LINENO: result: defaulting to $RUBY_CMD" >&5
+  RUBY_CMD="ruby"; RUBY_PATH=`dirname \`which ruby\``; { echo "$as_me:$LINENO: result: defaulting to $RUBY_CMD" >&5
 echo "${ECHO_T}defaulting to $RUBY_CMD" >&6; }
 fi
 
@@ -6316,7 +6316,7 @@ else
   ;;
   *)
   as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
+for as_dir in $RUBY_PATH
 do
   IFS=$as_save_IFS
   test -z "$as_dir" && as_dir=.
@@ -6330,6 +6330,7 @@ done
 done
 IFS=$as_save_IFS
 
+  test -z "$ac_cv_path_vi_cv_path_ruby" && ac_cv_path_vi_cv_path_ruby=""""
   ;;
 esac
 fi
@@ -6354,54 +6355,64 @@ echo $ECHO_N "checking Ruby header files... $ECHO_C" >&6; }
       rubyhdrdir=`$vi_cv_path_ruby -r mkmf -e 'print Config::CONFIG["rubyhdrdir"] || Config::CONFIG["archdir"] || $hdrdir' 2>/dev/null`
       if test "X$rubyhdrdir" != "X"; then
 	{ echo "$as_me:$LINENO: result: $rubyhdrdir" >&5
+
 echo "${ECHO_T}$rubyhdrdir" >&6; }
-	RUBY_CFLAGS="-I$rubyhdrdir"
-        rubyarch=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["arch"]'`
-        if test -d "$rubyhdrdir/$rubyarch"; then
-          RUBY_CFLAGS="$RUBY_CFLAGS -I$rubyhdrdir/$rubyarch"
-        fi
-        rubyversion=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["ruby_version"].gsub(/\./, "")[0,2]'`
-        RUBY_CFLAGS="$RUBY_CFLAGS -DRUBY_VERSION=$rubyversion"
-	rubylibs=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LIBS"]'`
-	if test "X$rubylibs" != "X"; then
-	  RUBY_LIBS="$rubylibs"
-	fi
-	librubyarg=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["LIBRUBYARG"])'`
-	if test -f "$rubyhdrdir/$librubyarg"; then
-	  librubyarg="$rubyhdrdir/$librubyarg"
-	else
-	  rubylibdir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["libdir"])'`
-          if test -d "/System/Library/Frameworks/Ruby.framework"; then
-                        RUBY_LIBS="-framework Ruby"
-                        RUBY_CFLAGS=
-            librubyarg=
-          elif test -f "$rubylibdir/$librubyarg"; then
-	    librubyarg="$rubylibdir/$librubyarg"
-	  elif test "$librubyarg" = "libruby.a"; then
-	    	    librubyarg="-lruby"
-	  else
-	    librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, %'-L#{Config.expand(Config::CONFIG[\"libdir\"])}')"`
-	  fi
-	fi
 
-	if test "X$librubyarg" != "X"; then
-	  RUBY_LIBS="$librubyarg $RUBY_LIBS"
-	fi
-	rubyldflags=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LDFLAGS"]'`
-	if test "X$rubyldflags" != "X"; then
-	  	  	  	  rubyldflags=`echo "$rubyldflags" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
-	  if test "X$rubyldflags" != "X"; then
-	    LDFLAGS="$rubyldflags $LDFLAGS"
-	  fi
-	fi
-        if test "X$rubyldflags" != "X"; then
-          LDFLAGS="$rubyldflags $LDFLAGS"
-        fi
-	RUBY_SRC="if_ruby.c"
-	RUBY_OBJ="objects/if_ruby.o"
-	RUBY_PRO="if_ruby.pro"
+RUBY_CFLAGS="-I$rubyhdrdir"
+rubyarch=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["arch"]'`
+if test -d "$rubyhdrdir/$rubyarch"; then
+  RUBY_CFLAGS="$RUBY_CFLAGS -I$rubyhdrdir/$rubyarch"
+fi
 
-	cat >>confdefs.h <<\_ACEOF
+rubyversion=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["ruby_version"].gsub(/\./, "")[0,2]'`
+RUBY_CFLAGS="$RUBY_CFLAGS -DRUBY_VERSION=$rubyversion"
+rubylibs=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LIBS"]'`
+
+if test "X$rubylibs" != "X"; then
+  RUBY_LIBS="$rubylibs"
+fi
+
+librubyarg=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["LIBRUBYARG"])'`
+if test -f "$rubyhdrdir/$librubyarg"; then
+  librubyarg="$rubyhdrdir/$librubyarg"
+else
+
+  rubylibdir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["libdir"])'`
+  if test "X$RUBY_PATH" != "X"; then
+    librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, '') << %' -L#{Config.expand(Config::CONFIG[\"libdir\"])}'"`
+  else
+    if test -d "/System/Library/Frameworks/Ruby.framework"; then
+                    RUBY_LIBS="-framework Ruby"
+                    RUBY_CFLAGS=
+      librubyarg=
+    elif test -f "$rubylibdir/$librubyarg"; then
+      librubyarg="$rubylibdir/$librubyarg"
+    elif test "$librubyarg" = "libruby.a"; then
+                    librubyarg="-lruby"
+    else
+      librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, '') << %' -L#{Config.expand(Config::CONFIG[\"libdir\"])}'"`
+    fi
+  fi
+fi
+
+if test "X$librubyarg" != "X"; then
+  RUBY_LIBS="$librubyarg $RUBY_LIBS"
+fi
+
+rubyldflags=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG["LDFLAGS"]'`
+if test "x$MACOSX" = "xyes"; then
+                                rubyldflags=`echo "$rubyldflags" | sed -e 's/-arch[^-]*//g'`
+fi
+if test "X$rubyldflags" != "X"; then
+  LDFLAGS="$rubyldflags $LDFLAGS"
+fi
+
+RUBY_SRC="if_ruby.c"
+RUBY_OBJ="objects/if_ruby.o"
+RUBY_PRO="if_ruby.pro"
+
+cat >>confdefs.h <<\_ACEOF
+
 #define FEAT_RUBY 1
 _ACEOF
 
@@ -6415,11 +6426,6 @@ echo "${ECHO_T}too old; need Ruby version 1.6.0 or later" >&6; }
     fi
   fi
 fi
-
-
-
-
-
 
 { echo "$as_me:$LINENO: checking --enable-cscope argument" >&5
 echo $ECHO_N "checking --enable-cscope argument... $ECHO_C" >&6; }

--- a/src/configure
+++ b/src/configure
@@ -6302,7 +6302,6 @@ else
 echo "${ECHO_T}defaulting to $RUBY_CMD" >&6; }
 fi
 
-
   # Extract the first word of "$RUBY_CMD", so it can be a program name with args.
 set dummy $RUBY_CMD; ac_word=$2
 { echo "$as_me:$LINENO: checking for $ac_word" >&5
@@ -6380,7 +6379,7 @@ else
   rubylibdir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG["libdir"])'`
   if test "X$RUBY_PATH" != "X"; then
     librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, '') << %' -L#{Config.expand(Config::CONFIG[\"libdir\"])}'"`
-  else
+  elif test "$RUBY_PATH" == "/usr/bin"; then
     if test -d "/System/Library/Frameworks/Ruby.framework"; then
                     RUBY_LIBS="-framework Ruby"
                     RUBY_CFLAGS=

--- a/src/configure.in
+++ b/src/configure.in
@@ -1335,12 +1335,17 @@ AC_ARG_ENABLE(rubyinterp,
 	[enable_rubyinterp="no"])
 AC_MSG_RESULT($enable_rubyinterp)
 if test "$enable_rubyinterp" = "yes"; then
+
+  #------------------------------------------------------------------------------------------------
   AC_MSG_CHECKING(--with-ruby-command argument)
   AC_ARG_WITH(ruby-command, [  --with-ruby-command=RUBY  name of the Ruby command (default: ruby)],
-	RUBY_CMD="$withval"; AC_MSG_RESULT($RUBY_CMD),
-	RUBY_CMD="ruby"; AC_MSG_RESULT(defaulting to $RUBY_CMD))
+    RUBY_PATH=`echo "$withval" | sed 's/\(.*\)\/\([[[^/]]]*\)$/\1/'`; RUBY_CMD=`echo "$withval" | sed 's/.*\/\([[[^/]]]*\)$/\1/'`; AC_MSG_RESULT($RUBY_CMD),
+    RUBY_CMD="ruby"; RUBY_PATH=`dirname \`which ruby\``; AC_MSG_RESULT(defaulting to $RUBY_CMD)
+  )
+  
+  AC_PATH_PROG(vi_cv_path_ruby, $RUBY_CMD, "", $RUBY_PATH)
   AC_SUBST(vi_cv_path_ruby)
-  AC_PATH_PROG(vi_cv_path_ruby, $RUBY_CMD)
+
   if test "X$vi_cv_path_ruby" != "X"; then
     AC_MSG_CHECKING(Ruby version)
     if $vi_cv_path_ruby -e '(VERSION rescue RUBY_VERSION) >= "1.6.0" or exit 1' >/dev/null 2>/dev/null; then

--- a/src/configure.in
+++ b/src/configure.in
@@ -1331,21 +1331,16 @@ AC_SUBST(TCL_LIBS)
 
 AC_MSG_CHECKING(--enable-rubyinterp argument)
 AC_ARG_ENABLE(rubyinterp,
-	[  --enable-rubyinterp     Include Ruby interpreter.], ,
+	[  --enable-rubyinterp[=OPTS]     Include Ruby interpreter.  [default=no] [OPTS=no/yes/dynamic]], ,
 	[enable_rubyinterp="no"])
 AC_MSG_RESULT($enable_rubyinterp)
-if test "$enable_rubyinterp" = "yes"; then
-
-  #------------------------------------------------------------------------------------------------
+if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
   AC_MSG_CHECKING(--with-ruby-command argument)
   AC_ARG_WITH(ruby-command, [  --with-ruby-command=RUBY  name of the Ruby command (default: ruby)],
-    RUBY_PATH=`echo "$withval" | sed 's/\(.*\)\/\([[[^/]]]*\)$/\1/'`; RUBY_CMD=`echo "$withval" | sed 's/.*\/\([[[^/]]]*\)$/\1/'`; AC_MSG_RESULT($RUBY_CMD),
-    RUBY_CMD="ruby"; RUBY_PATH=`dirname \`which ruby\``; AC_MSG_RESULT(defaulting to $RUBY_CMD)
-  )
-  
-  AC_PATH_PROG(vi_cv_path_ruby, $RUBY_CMD, "", $RUBY_PATH)
+	RUBY_CMD="$withval"; AC_MSG_RESULT($RUBY_CMD),
+	RUBY_CMD="ruby"; AC_MSG_RESULT(defaulting to $RUBY_CMD))
   AC_SUBST(vi_cv_path_ruby)
-
+  AC_PATH_PROG(vi_cv_path_ruby, $RUBY_CMD)
   if test "X$vi_cv_path_ruby" != "X"; then
     AC_MSG_CHECKING(Ruby version)
     if $vi_cv_path_ruby -e '(VERSION rescue RUBY_VERSION) >= "1.6.0" or exit 1' >/dev/null 2>/dev/null; then
@@ -1407,6 +1402,12 @@ if test "$enable_rubyinterp" = "yes"; then
 	RUBY_PRO="if_ruby.pro"
 
 	AC_DEFINE(FEAT_RUBY)
+	if test "$enable_rubyinterp" = "dynamic"; then
+	  libruby=`$vi_cv_path_ruby -r rbconfig -e 'printf "lib%s.%s\n", Config::CONFIG[["RUBY_SO_NAME"]], Config::CONFIG[["DLEXT"]]'`
+	  AC_DEFINE(DYNAMIC_RUBY)
+	  RUBY_CFLAGS="-DDYNAMIC_RUBY_DLL=\\\"$libruby\\\" -DDYNAMIC_RUBY_VER=$rubyversion $RUBY_CFLAGS"
+	  RUBY_LIBS=
+	fi
       else
 	AC_MSG_RESULT(not found; disabling Ruby)
       fi

--- a/src/configure.in
+++ b/src/configure.in
@@ -1334,13 +1334,18 @@ AC_ARG_ENABLE(rubyinterp,
 	[  --enable-rubyinterp[=OPTS]     Include Ruby interpreter.  [default=no] [OPTS=no/yes/dynamic]], ,
 	[enable_rubyinterp="no"])
 AC_MSG_RESULT($enable_rubyinterp)
+
 if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
   AC_MSG_CHECKING(--with-ruby-command argument)
   AC_ARG_WITH(ruby-command, [  --with-ruby-command=RUBY  name of the Ruby command (default: ruby)],
-	RUBY_CMD="$withval"; AC_MSG_RESULT($RUBY_CMD),
-	RUBY_CMD="ruby"; AC_MSG_RESULT(defaulting to $RUBY_CMD))
+    [ RUBY_CMD="$withval"; with_custom_ruby="true"; vi_cv_path_ruby="$withval"; AC_MSG_RESULT($RUBY_CMD) ],
+    [ RUBY_CMD="/usr/bin/ruby"; with_custom_ruby="false"; vi_cv_path_ruby="/usr/bin/ruby"; AC_MSG_RESULT(defaulting to $RUBY_CMD) ] )
+
+  AC_SUBST(with_custom_ruby)
   AC_SUBST(vi_cv_path_ruby)
+
   AC_PATH_PROG(vi_cv_path_ruby, $RUBY_CMD)
+
   if test "X$vi_cv_path_ruby" != "X"; then
     AC_MSG_CHECKING(Ruby version)
     if $vi_cv_path_ruby -e '(VERSION rescue RUBY_VERSION) >= "1.6.0" or exit 1' >/dev/null 2>/dev/null; then
@@ -1348,74 +1353,93 @@ if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
       AC_MSG_CHECKING(Ruby header files)
       rubyhdrdir=`$vi_cv_path_ruby -r mkmf -e 'print Config::CONFIG[["rubyhdrdir"]] || Config::CONFIG[["archdir"]] || $hdrdir' 2>/dev/null`
       if test "X$rubyhdrdir" != "X"; then
-	AC_MSG_RESULT($rubyhdrdir)
-	RUBY_CFLAGS="-I$rubyhdrdir"
+        AC_MSG_RESULT($rubyhdrdir)
+
+        RUBY_CFLAGS="-I$rubyhdrdir"
         rubyarch=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG[["arch"]]'`
+
         if test -d "$rubyhdrdir/$rubyarch"; then
           RUBY_CFLAGS="$RUBY_CFLAGS -I$rubyhdrdir/$rubyarch"
         fi
+
         rubyversion=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG[["ruby_version"]].gsub(/\./, "")[[0,2]]'`
         RUBY_CFLAGS="$RUBY_CFLAGS -DRUBY_VERSION=$rubyversion"
-	rubylibs=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG[["LIBS"]]'`
-	if test "X$rubylibs" != "X"; then
-	  RUBY_LIBS="$rubylibs"
-	fi
-	librubyarg=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG[["LIBRUBYARG"]])'`
-	if test -f "$rubyhdrdir/$librubyarg"; then
-	  librubyarg="$rubyhdrdir/$librubyarg"
-	else
-	  rubylibdir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG[["libdir"]])'`
+        rubylibs=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG[["LIBS"]]'`
+
+        if test "X$rubylibs" != "X"; then
+          RUBY_LIBS="$rubylibs"
+        fi
+
+        librubyarg=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG[["LIBRUBYARG"]])'`
+        librubystatic=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG[["LIBRUBY_A"]])'`
+        librubydir=`$vi_cv_path_ruby -r rbconfig -e 'print Config.expand(Config::CONFIG[["libdir"]])'`
+
+        if test "$with_custom_ruby" == "false"; then
           if test -d "/System/Library/Frameworks/Ruby.framework"; then
             dnl On Mac OS X it is safer to just use the -framework flag
             RUBY_LIBS="-framework Ruby"
             dnl Don't include the -I flag when -framework is set
             RUBY_CFLAGS=
             librubyarg=
-          elif test -f "$rubylibdir/$librubyarg"; then
-	    librubyarg="$rubylibdir/$librubyarg"
-	  elif test "$librubyarg" = "libruby.a"; then
-	    dnl required on Mac OS 10.3 where libruby.a doesn't exist
-	    librubyarg="-lruby"
-	  else
-	    librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print '$librubyarg'.gsub(/-L\./, %'-L#{Config.expand(Config::CONFIG[\"libdir\"])}')"`
-	  fi
-	fi
+          elif test -f "$librubydir/$librubystatic"; then
+            librubyarg="$librubyarg"
+            RUBY_LIBS="-L$librubydir"
+          elif test "$librubyarg" = "libruby.a"; then
+            librubyarg="-lruby"
+            RUBY_LIBS="-L$librubydir"
+          fi
+        else
+          if test -f "$librubydir/$librubystatic"; then
+            librubyarg="$librubyarg"
+            RUBY_LIBS="-L$librubydir"
+          elif test "$librubyarg" = "libruby.a"; then
+            librubyarg="-lruby"
+            RUBY_LIBS="-L$librubydir"
+          fi
+        fi
 
-	if test "X$librubyarg" != "X"; then
-	  RUBY_LIBS="$librubyarg $RUBY_LIBS"
-	fi
-	rubyldflags=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG[["LDFLAGS"]]'`
-	if test "X$rubyldflags" != "X"; then
-	  dnl Ruby on Mac OS X 10.5 adds "-arch" flags but these should only
-	  dnl be included if requested by passing --with-mac-arch to
-	  dnl configure, so strip these flags first (if present)
-	  rubyldflags=`echo "$rubyldflags" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
-	  if test "X$rubyldflags" != "X"; then
-	    LDFLAGS="$rubyldflags $LDFLAGS"
-	  fi
-	fi
+        if test "X$librubyarg" != "X"; then
+          RUBY_LIBS="$librubyarg $RUBY_LIBS"
+        fi
+
+        rubyldflags=`$vi_cv_path_ruby -r rbconfig -e 'print Config::CONFIG[["LDFLAGS"]]'`
+
+        if test "X$rubyldflags" != "X"; then
+          dnl Ruby on Mac OS X 10.5 adds "-arch" flags but these should only
+          dnl be included if requested by passing --with-mac-arch to
+          dnl configure, so strip these flags first (if present)
+          rubyldflags=`echo "$rubyldflags" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
+          if test "X$rubyldflags" != "X"; then
+            LDFLAGS="$rubyldflags $LDFLAGS"
+          fi
+        fi
+
         if test "X$rubyldflags" != "X"; then
           LDFLAGS="$rubyldflags $LDFLAGS"
         fi
-	RUBY_SRC="if_ruby.c"
-	RUBY_OBJ="objects/if_ruby.o"
-	RUBY_PRO="if_ruby.pro"
 
-	AC_DEFINE(FEAT_RUBY)
-	if test "$enable_rubyinterp" = "dynamic"; then
-	  libruby=`$vi_cv_path_ruby -r rbconfig -e 'printf "lib%s.%s\n", Config::CONFIG[["RUBY_SO_NAME"]], Config::CONFIG[["DLEXT"]]'`
-	  AC_DEFINE(DYNAMIC_RUBY)
-	  RUBY_CFLAGS="-DDYNAMIC_RUBY_DLL=\\\"$libruby\\\" -DDYNAMIC_RUBY_VER=$rubyversion $RUBY_CFLAGS"
-	  RUBY_LIBS=
-	fi
+        RUBY_SRC="if_ruby.c"
+        RUBY_OBJ="objects/if_ruby.o"
+        RUBY_PRO="if_ruby.pro"
+
+        AC_DEFINE(FEAT_RUBY)
+
+dnl        if test "$enable_rubyinterp" = "dynamic"; then
+dnl          libruby=`$vi_cv_path_ruby -r rbconfig -e 'printf "lib%s.%s\n", Config::CONFIG[["RUBY_SO_NAME"]], Config::CONFIG[["DLEXT"]]'`
+dnl          AC_DEFINE(DYNAMIC_RUBY)
+dnl          RUBY_CFLAGS="-DDYNAMIC_RUBY_DLL=\\\"$libruby\\\" -DDYNAMIC_RUBY_VER=$rubyversion $RUBY_CFLAGS"
+dnl          RUBY_LIBS=
+dnl        fi
+
       else
-	AC_MSG_RESULT(not found; disabling Ruby)
+        AC_MSG_RESULT(not found; disabling Ruby)
       fi
     else
       AC_MSG_RESULT(too old; need Ruby version 1.6.0 or later)
     fi
   fi
 fi
+
 AC_SUBST(RUBY_SRC)
 AC_SUBST(RUBY_OBJ)
 AC_SUBST(RUBY_PRO)


### PR DESCRIPTION
hi, as per the discussion here http://vim.1045645.n5.nabble.com/MacVim-Ruby-1-9-1-td1220105.html I re-created the changes made to src/configure and src/configure.in to make it pick up the right ruby version. I was then able to do ./configure --enable-rubyinterp --with-ruby=`which ruby` and link against 1.9.2 installed with rvm. thanks to the author of the initial patch! 
