### PR TITLE
Fix to update cursor at the IM state changed

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1657,6 +1657,9 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
 - (void)setImState:(BOOL)activated
 {
     imState = activated;
+
+    gui_update_cursor(TRUE, FALSE);
+    [self flushQueue:YES];
 }
 
 static void netbeansReadCallback(CFSocketRef s,


### PR DESCRIPTION
> I noticed one slight problem: if the cursor blinking is turned off (:set gcr=a:blinkon0) and ":hi CursorIM ..." is set then the cursor color doesn't change immediately when you switch input source. My guess is that you have to go into MMBackend.m and make sure Vim updates when the IM message is received.

Ok, I have fixed it. MMBackend class setImState method calls gui_update_cursor and flushQueue for changing the cursor immediately.
