### PR TITLE
Bug fix for 316: URL Scheme handler not handling paths with spaces via percent escaping

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1616,6 +1616,11 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 {
     NSString *urlString = [[event paramDescriptorForKeyword:keyDirectObject]
         stringValue];
+    // Bug 316: The URL handler isn't properly handling paths with spaces 
+    // via percent escaped encoding.
+    // The fix seems to be to convert the incoming string to use percent
+    // escaping before converting it to a NSURL.
+    urlString = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     NSURL *url = [NSURL URLWithString:urlString];
 
     // We try to be compatible with TextMate's URL scheme here, as documented


### PR DESCRIPTION
This contains a simple fix for bug 316 where using URLs with spaces in paths via percent escaping fails, e.g.
mvim://open?url=file://foo/untilted%20folder/main.lua
