### PR TITLE
list of search directories in mvim script

### DIFF
--- a/src/MacVim/mvim
+++ b/src/MacVim/mvim
@@ -17,8 +17,14 @@ if [ -z "$VIM_APP_DIR" ]
 then
 	myDir="`dirname "$0"`"
 	myAppDir="$myDir/../Applications"
-	for i in ~/Applications ~/Applications/vim $myDir $myDir/vim $myAppDir $myAppDir/vim /Applications /Applications/vim /Applications/Utilities /Applications/Utilities/vim; do
+	for i in ~/Applications $myDir $myAppDir /Applications /Applications/Utilities /Developer/Applications /Developer/Applications/Utilities ; do
+		# first look in the directory itself...
 		if [ -x "$i/MacVim.app" ]; then
+			VIM_APP_DIR="$i"
+			break
+		fi
+		# next look in the 'vim' sub-directory...
+		if [ -x "$i/vim/MacVim.app" ]; then
 			VIM_APP_DIR="$i"
 			break
 		fi


### PR DESCRIPTION
Hi b4winckler,

The attached pull request adds `/Developer/Applications` and `/Developer/Applications/Utilities` to the list of directories that is searched for the `MacVim.app` bundle.

A second, minor change in the pull request refactors the way in which the `vim` sub-directory of each search directory on the list is processed.

Thanks for your consideration,

Peter Vandenberk
