### PR TITLE
Patch for Issue#299

### DIFF
--- a/src/MacVim/icons/Makefile
+++ b/src/MacVim/icons/Makefile
@@ -1,8 +1,14 @@
 .PHONY: clean
 
+ifdef ENVYCODER
+	iconfont = Envy\ Code\ R\ Bold.ttf
+else
+	iconfont = 
+endif
+
 OUTDIR ?= .
 
-$(OUTDIR)/MacVim-generic.icns: make_icons.py vim-noshadow-512.png loadfont.so Envy\ Code\ R\ Bold.ttf
+$(OUTDIR)/MacVim-generic.icns: make_icons.py vim-noshadow-512.png loadfont.so $(iconfont)
 	$(MAKE) -C makeicns
 	/usr/bin/python make_icons.py $(OUTDIR)
 

--- a/src/MacVim/icons/make_icons.py
+++ b/src/MacVim/icons/make_icons.py
@@ -13,8 +13,10 @@ try:
   # Load Envy Code R from a file and register it under its postscript name
   # Thanks to DamienG for this font (redistributed with permission):
   # http://damieng.com/blog/2008/05/26/envy-code-r-preview-7-coding-font-released
+  fontname = 'Envy Code R Bold.ttf'
   import loadfont
-  loadfont.loadfont('Envy Code R Bold.ttf')
+  if not loadfont.loadfont(fontname):
+    raise RuntimeError("Could not load font " + fontname)
 
   from Foundation import NSString
   from AppKit import *

--- a/src/configure.in
+++ b/src/configure.in
@@ -212,6 +212,19 @@ fi
 AC_SUBST(OS_EXTRA_SRC)
 AC_SUBST(OS_EXTRA_OBJ)
 
+
+if test "x$MACOSX" = "xyes"; then
+  AC_MSG_CHECKING(--enable-envycoder argument)
+  AC_ARG_ENABLE(envycoder,
+    [  --enable-envycoder         Build with Envy Code R Bold font], ,
+    [enable_envycoder="no"])
+  AC_MSG_RESULT($enable_envycoder)
+  if test "$enable_envycoder" = "yes"; then
+    AC_DEFINE(FEAT_ENVYCODER)
+  fi
+fi
+
+
 dnl Add /usr/local/lib to $LDFLAGS and /usr/local/include to CFLAGS.
 dnl Only when the directory exists and it wasn't there yet.
 dnl For gcc don't do this when it is already in the default search path.


### PR DESCRIPTION
I added a configure option --enable-envycoder which is off by default.  I also modified make_icons.py so that it would gracefully fail if the font was not found.

This is probably not the best solution, but it gets around builds failing on a clean checkout when damieng.com is down.
