### PR TITLE
Quicklook for VHDL files

### DIFF
--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1171,6 +1171,19 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>VHDL Source File</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>vhd</string>
+				<string>vhdl</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>MacVim-vhd</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>

--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -2568,6 +2568,24 @@
 				</array>
 			</dict>
 		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>VHDL source file</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.vim.vhdl-file</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>vhdl</string>
+					<string>vhd</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi,

I've added VHDL files to the list of supported files to Info.plist. Seems to work just fine here; I can now quickview files in Versions and Finder.
