### PR TITLE
Untitled

### DIFF
--- a/src/MacVim/icons/Makefile
+++ b/src/MacVim/icons/Makefile
@@ -7,7 +7,7 @@ $(OUTDIR)/MacVim-generic.icns: make_icons.py vim-noshadow-512.png loadfont.so
 	/usr/bin/python make_icons.py $(OUTDIR)
 
 loadfont.so: loadfont.c
-	/usr/bin/python setup.py install --install-lib .
+	ARCHFLAGS='-arch x86_64 -arch i386' /usr/bin/python setup.py install --install-lib .
 
 getenvy: Envy\ Code\ R\ Bold.ttf
 


### PR DESCRIPTION
Fix macvim compilation with Xcode4.

Make loadfont.c compile without ppc architecture, allowing macvim
be built with Xcode4.

If ARCHFLAGS environment variable is not set, python distutils
(used by setup.py) sets -arch command line arguments for gcc to
'-arch x86_x64 -arch ppc -arch i386', thus gcc is trying to build
universal binary with ppc support.

Xcode4 does not contain command line tools for ppc platform
(assembler tools). As a result ppc architecture is failed to build,
loadfont.c is not compiled, icons are note generated and macvim
is failed to build.

Explicit setting ARCHFLAGS environment variable in Makefile 
solves the problem.
