### PR TITLE
Honor VIM and VIMRUNTIME environment variables

### DIFF
--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -51,15 +51,23 @@ vimmenu_T *menu_for_descriptor(NSArray *desc);
     void
 macvim_early_init()
 {
+    char_u *p;
     NSBundle *bundle = [NSBundle mainBundle];
     if (bundle) {
         // Set environment variables $VIM and $VIMRUNTIME
         NSString *path = [[bundle resourcePath]
                                         stringByAppendingPathComponent:@"vim"];
-        vim_setenv((char_u*)"VIM", (char_u*)[path UTF8String]);
 
-        path = [path stringByAppendingPathComponent:@"runtime"];
-        vim_setenv((char_u*)"VIMRUNTIME", (char_u*)[path UTF8String]);
+        p = mch_getenv((char_u *)"VIM");
+        if (p == NULL || *p == NUL) {
+            vim_setenv((char_u*)"VIM", (char_u*)[path UTF8String]);
+        }
+
+        p = mch_getenv((char_u *)"VIMRUNTIME");
+        if (p == NULL || *p == NUL) {
+            path = [path stringByAppendingPathComponent:@"runtime"];
+            vim_setenv((char_u*)"VIMRUNTIME", (char_u*)[path UTF8String]);
+        }
     }
 
 #if 0   // NOTE: setlocale(LC_ALL, "") seems to work after a restart so this is


### PR DESCRIPTION
Currently environment variables $VIM and $VIMRUNTIME are ignored by macvim. Using vanilla vim it is possible to set $VIM so I can share a specialized vim setup with other developers over NFS and I would very much like to do this with macvim as well, so I hope you'll consider including this little patch.

Thanks,

..Jess Thrysoee
