### PR TITLE
Please consider adding this change to fix problems with Dvorak-Qwerty+Cmd layouts (and possibly others)

### DIFF
--- a/src/MacVim/MMTextViewHelper.m
+++ b/src/MacVim/MMTextViewHelper.m
@@ -228,6 +228,13 @@ KeyboardInputSourcesEqual(TISInputSourceRef a, TISInputSourceRef b)
         // automatically, hence the explicit unmarkText: call here.
         [self unmarkText];
     }
+    if (!imControl) {
+        // We got called by Cocoa, but we really don't have a reason to be here, because we are
+        // not an input method, so just go the normal key route. This can happen at least with the
+        // Dvorak-Qwerty CMD layout, and likely others.
+        interpretKeyEventsSwallowedKey = NO;
+        return;
+    }
 
     // NOTE: 'string' is either an NSString or an NSAttributedString.  Since we
     // do not support attributes, simply pass the corresponding NSString in the


### PR DESCRIPTION
Begin quoting from my change:

It seems that this layout will cause the input method methods to be
called, whereas "normal" layouts don't go this route. The problem is
that this sends the wrong text (namely a ',' in the case when the user
pressed 'w'). However, we also need to set the
"interpretKeyEventsSwallowedKey flag since in this particular case we
really mean that a selector didn't swallow this key.

Yes, it's complicated and this layout is used by a very small minority.
But this layout is handy enough to support, kind of like the Mac users
of old. :-)

End Quote.

If it helps for convincing, this pattern for handling text is also used in Qt for its text editing widgets (see http://qt.gitorious.org/qt/qt/commit/9377881d6d6f5c07aa134c8f1708d0afd0d06e86), I know this because I was the person that got to double-check the code before it was submitted.

Certainly open for other ways of doing patch if desired.
