### PR TITLE
Fix missing selector for 10.6 or earlier

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -243,7 +243,8 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
     // Disable automatic relaunching
-    [NSApp disableRelaunchOnLogin];
+    if ([NSApp respondsToSelector:@selector(disableRelaunchOnLogin)])
+        [NSApp disableRelaunchOnLogin];
 #endif
 
     vimControllers = [NSMutableArray new];

--- a/src/MacVim/MMVimController.m
+++ b/src/MacVim/MMVimController.m
@@ -766,21 +766,30 @@ static BOOL isUnsafeMessage(int msgid);
         [self setServerName:name];
         [name release];
     } else if (EnterFullscreenMsgID == msgid) {
-#if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_7)
-        const void *bytes = [data bytes];
-        int fuoptions = *((int*)bytes); bytes += sizeof(int);
-        int bg = *((int*)bytes);
-        NSColor *back = [NSColor colorWithArgbInt:bg];
+#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
+        if ([[windowController window]
+                respondsToSelector:@selector(toggleFullScreen:)]) {
+            [[windowController window] toggleFullScreen:self];
+        } else {
+#endif
+            const void *bytes = [data bytes];
+            int fuoptions = *((int*)bytes); bytes += sizeof(int);
+            int bg = *((int*)bytes);
+            NSColor *back = [NSColor colorWithArgbInt:bg];
 
-        [windowController enterFullscreen:fuoptions backgroundColor:back];
-#else
-        [[windowController window] toggleFullScreen:self];
+            [windowController enterFullscreen:fuoptions backgroundColor:back];
+#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
+        }
 #endif
     } else if (LeaveFullscreenMsgID == msgid) {
-#if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_7)
-        [windowController leaveFullscreen];
-#else
-        [[windowController window] toggleFullScreen:self];
+#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
+        if ([windowController respondsToSelector:@selector(leaveFullscreen)]) {
+            [windowController leaveFullscreen];
+        } else {
+#endif
+            [[windowController window] toggleFullScreen:self];
+#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
+        }
 #endif
     } else if (SetBuffersModifiedMsgID == msgid) {
         const void *bytes = [data bytes];

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -182,7 +182,8 @@
         [win _setContentHasShadow:NO];
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
-    [win setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
+    if ([win respondsToSelector:@selector(setCollectionBehavior:)])
+        [win setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
 #endif
 
     return self;


### PR DESCRIPTION
Hi,

I created a patch for missing selector of 10.6 or earlier. lion branch with Deployment Target=10.6 works fine on 10.6.
