### PR TITLE
Fix to draw the underline for inline IM inputs

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4526,7 +4526,9 @@ win_line(wp, lnum, startrow, endrow, nochange)
 # endif
 		lnum == wp->w_cursor.lnum
 		&& (State & INSERT)
+# ifndef FEAT_GUI_MACVIM
 		&& !p_imdisable
+# endif
 		&& im_is_preediting()
 		&& draw_state == WL_LINE)
 	{


### PR DESCRIPTION
Hi,

I've noticed that MacVim doesn't draw the underline for inline IM inputs when imdisable is set. I created a patch to ignore imdisable flag for it.
