### PR TITLE
Build: Fix issues with spaces in path

### DIFF
--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
@@ -538,7 +538,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Clear deployment target, else the python script always thinks we're building on Tiger\nunset MACOSX_DEPLOYMENT_TARGET\n\n# Generate the icons (redirect stderr to ignore warnings)\ncd $PROJECT_DIR/icons/\nmake OUTDIR=$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH 2> /dev/null\n";
+			shellScript = "# Clear deployment target, else the python script always thinks we're building on Tiger\nunset MACOSX_DEPLOYMENT_TARGET\n\n# Generate the icons (redirect stderr to ignore warnings)\ncd \"$PROJECT_DIR\"/icons/\nmake OUTDIR=\"$TARGET_BUILD_DIR\"/$UNLOCALIZED_RESOURCES_FOLDER_PATH 2> /dev/null\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/src/MacVim/icons/Makefile
+++ b/src/MacVim/icons/Makefile
@@ -16,12 +16,12 @@ OUTDIR ?= .
 # step requires an internet connection.
 
 $(OUTDIR)/MacVim-generic.icns:
-	cp -pR MacVim-*.icns $(OUTDIR)/
+	cp -pR MacVim-*.icns "$(OUTDIR)"/
 
 all: make_icons.py vim-noshadow-512.png loadfont.so
 	rm -f MacVim-*.icns
 	$(MAKE) -C makeicns
-	/usr/bin/python make_icons.py $(OUTDIR)
+	/usr/bin/python make_icons.py "$(OUTDIR)"
 
 loadfont.so: loadfont.c
 	/usr/bin/python setup.py install --install-lib .
@@ -40,6 +40,6 @@ EnvyCodeR.zip:
 
 clean:
 	$(MAKE) -C makeicns clean
-	rm -f $(OUTDIR)/MacVim-*.icns loadfont.so *.pyc \
+	rm -f "$(OUTDIR)"/MacVim-*.icns loadfont.so *.pyc \
 	  EnvyCodeR.zip *.ttf *.reg *.txt
 	rm -rf *.egginfo build  # Created by setup.py


### PR DESCRIPTION
Build would fail during the Make Document Icons phase with spaces present in the path to the source. I've quoted the relevant variables in both this phase's shellscript and the icons Makefile, and subsequently succeeded in building a working MacVim
