### PR TITLE
Noted --help param to reduce initial confusion

### DIFF
--- a/README_mac.txt
+++ b/README_mac.txt
@@ -12,7 +12,9 @@ install in (usually `/Applications').
 How to build and install
 ========================
 
-Run `./configure` in the `src/` directory with the flags you want, e.g.:
+Run `./configure` in the `src/` directory with the flags you want 
+(call "./configure --help" to see a list of flags)
+e.g.:
 
     $ cd src
     $ ./configure --with-features=huge \


### PR DESCRIPTION
I spent a few minutes trying to figure out where the params were documented. only after I played around with it and read some other docs did I discover this flag. Thanks.
