### PR TITLE
Fix processing of netbeans messages.

### DIFF
--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -392,6 +392,11 @@ gui_mch_wait_for_chars(int wtime)
     // called, so force a flush of the command queue here.
     [[MMBackend sharedInstance] flushQueue:YES];
 
+#if defined(FEAT_NETBEANS_INTG)
+    /* Process any queued netbeans messages. */
+    netbeans_parse_messages();
+#endif
+
     return [[MMBackend sharedInstance] waitForInput:wtime];
 }
 


### PR DESCRIPTION
As [mentioned](http://groups.google.com/group/vim_mac/browse_thread/thread/e0e90599a36efcab) on the vim_mac mailing list, processing of netbeans messages in macvim has been broken since b4winckler/macvim@1e08012084f0d293c4046419307835ca4cf06606. This commit adds a call to `netbeans_parse_messages()` into `gui_macvim.m` to mimic the same call moved from `netbeans.c` into `gui_x11.c` in vim.
