### PR TITLE
Suppress warnings on OS X 10.5 when compiling makeicns utility

### DIFF
--- a/src/MacVim/icons/makeicns/Makefile
+++ b/src/MacVim/icons/makeicns/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -fpascal-strings -O2
+CFLAGS = -fpascal-strings -O2 -Wno-deprecated-declarations -Wno-format
 
 .PHONY: clean dist
 


### PR DESCRIPTION
A few NSFileManager and CG methods were deprecated in OS X v10.5 and are
now causing warnings during compilation. Because of this the custom
icons have been made optional and the default build does not provide
them anymore.

This is a workaround fix to suppress the warning messages until the
source code is updated properly.
