### PR TITLE
Fold columns configuration

### DIFF
--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -540,16 +540,17 @@ fold column:
 
 OTHER OPTIONS
 
-'foldenable'  'fen':	Open all folds while not set.
-'foldexpr'    'fde':	Expression used for "expr" folding.
-'foldignore'  'fdi':	Characters used for "indent" folding.
-'foldmarker'  'fmr':	Defined markers used for "marker" folding.
-'foldmethod'  'fdm':	Name of the current folding method.
-'foldminlines' 'fml':	Minimum number of screen lines for a fold to be
-			displayed closed.
-'foldnestmax' 'fdn':	Maximum nesting for "indent" and "syntax" folding.
-'foldopen'    'fdo':	Which kinds of commands open closed folds.
-'foldclose'   'fcl':	When the folds not under the cursor are closed.
+'foldcolshowlvl'  'fsl':	Show a number representing the fold level.
+'foldenable'      'fen':	Open all folds while not set.
+'foldexpr'        'fde':	Expression used for "expr" folding.
+'foldignore'      'fdi':	Characters used for "indent" folding.
+'foldmarker'      'fmr':	Defined markers used for "marker" folding.
+'foldmethod'      'fdm':	Name of the current folding method.
+'foldminlines'    'fml':	Minimum number of screen lines for a fold to be
+				displayed closed.
+'foldnestmax'     'fdn':	Maximum nesting for "indent" and "syntax" folding.
+'foldopen'        'fdo':	Which kinds of commands open closed folds.
+'foldclose'       'fcl':	When the folds not under the cursor are closed.
 
 ==============================================================================
 4. Behavior of folds					*fold-behavior*

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -540,6 +540,7 @@ fold column:
 
 OTHER OPTIONS
 
+'foldchars'       'fds':	Characters used to be used on the fold column.
 'foldcolshowlvl'  'fsl':	Show a number representing the fold level.
 'foldenable'      'fen':	Open all folds while not set.
 'foldexpr'        'fde':	Expression used for "expr" folding.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3033,6 +3033,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	value is 12.
 	See |folding|.
 
+						*'foldcolshowlvl'* *'fsl'*
+'foldcolshowlvl' 'fsl'	boolean (default on)
+			local to window
+			{not in Vi}
+			{not available when compiled without the |+folding|
+			feature}
+        When off, the fold column will not show the number representing the
+        fold level when your |foldcolumn| option is set to a value lower than
+        the amount of fold levels.
+
 			*'foldenable'* *'fen'* *'nofoldenable'* *'nofen'*
 'foldenable' 'fen'	boolean (default on)
 			local to window

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -680,9 +680,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"single":	Use the same width as characters in US-ASCII.  This is
 			expected by most users.
 	"double":	Use twice the width of ASCII characters.
-							*E834* *E835*
-	The value "double" cannot be used if 'listchars' or 'fillchars'
-	contains a character that would be double width.
+						*E834* *E835* *E836*
+	The value "double" cannot be used if 'listchars', 'fillchars' or
+	'foldchars' contains a character that would be double width.
 
 	There are a number of CJK fonts for which the width of glyphs for
 	those characters are solely based on how many octets they take in
@@ -3012,6 +3012,31 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Normally you would set 'allowrevins' and use CTRL-_ in insert mode to
 	toggle this option |i_CTRL-_|.  See |farsi.txt|.
 
+						*'foldchars'* *'fds'*
+'foldchars' 'fds'	string	(default "fa:|,fo:-,fc:+")
+			global
+			{not in Vi}
+	Characters to use in 'fold column' when fold is enabled.  It is a
+	comma separated list of string settings.
+	  						*fds-fa*
+	  fa:c		Character to represent a fold area. This character is
+                        only used if the fold area is not the beginning of a
+                        fold and the line is not folded.
+	  						*fds-fc*
+	  fc:c		Character to represent the beginning of a fold when the
+                        given fold is closed.
+	  						*fds-fo*
+	  fo:c		Character to represent the beginning of a fold when the
+                        given fold is opened.
+
+	The characters ':' and ',' should not be used.  UTF-8 characters can
+	be used when 'encoding' is "utf-8", otherwise only printable
+	characters are allowed.  All characters must be single width.
+
+	Examples: >
+	    :set fds=fa:\|,fo:-,fc:+
+	    :set fds=fa:\ ,fo:-,fc:+
+	    :set fds=fa:\ ,fo:▾,fc:▸
 						*'foldclose'* *'fcl'*
 'foldclose' 'fcl'	string (default "")
 			global

--- a/src/globals.h
+++ b/src/globals.h
@@ -1159,6 +1159,12 @@ EXTERN int	lcs_trail INIT(= NUL);
 EXTERN int	lcs_conceal INIT(= '-');
 #endif
 
+#ifdef FEAT_FOLDING
+EXTERN int	fds_fo INIT(= '-');
+EXTERN int	fds_fc INIT(= '+');
+EXTERN int	fds_fa INIT(= '|');
+#endif
+
 #if defined(FEAT_WINDOWS) || defined(FEAT_WILDMENU) || defined(FEAT_STL_OPT) \
 	|| defined(FEAT_FOLDING)
 /* Characters from 'fillchars' option */

--- a/src/option.c
+++ b/src/option.c
@@ -194,6 +194,7 @@
 # define PV_DIFF	OPT_WIN(WV_DIFF)
 #endif
 #ifdef FEAT_FOLDING
+# define PV_FSL		OPT_WIN(WV_FSL)
 # define PV_FDC		OPT_WIN(WV_FDC)
 # define PV_FEN		OPT_WIN(WV_FEN)
 # define PV_FDI		OPT_WIN(WV_FDI)
@@ -1149,6 +1150,9 @@ static struct vimoption
     {"foldclose",   "fcl",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP|P_RWIN,
 			    (char_u *)&p_fcl, PV_NONE,
 			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+    {"foldcolshowlvl","fsl",P_BOOL|P_VI_DEF|P_RWIN,
+			    (char_u *)VAR_WIN, PV_FSL,
+			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
     {"foldcolumn",  "fdc",  P_NUM|P_VI_DEF|P_RWIN,
 			    (char_u *)VAR_WIN, PV_FDC,
 			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
@@ -9795,6 +9799,7 @@ get_varp(p)
 #endif
 #ifdef FEAT_FOLDING
 	case PV_FDC:	return (char_u *)&(curwin->w_p_fdc);
+	case PV_FSL:	return (char_u *)&(curwin->w_p_fsl);
 	case PV_FEN:	return (char_u *)&(curwin->w_p_fen);
 	case PV_FDI:	return (char_u *)&(curwin->w_p_fdi);
 	case PV_FDL:	return (char_u *)&(curwin->w_p_fdl);
@@ -10041,6 +10046,7 @@ copy_winopt(from, to)
     to->wo_cole = from->wo_cole;
 #endif
 #ifdef FEAT_FOLDING
+    to->wo_fsl = from->wo_fsl;
     to->wo_fdc = from->wo_fdc;
     to->wo_fen = from->wo_fen;
     to->wo_fdi = vim_strsave(from->wo_fdi);

--- a/src/option.h
+++ b/src/option.h
@@ -1072,6 +1072,7 @@ enum
 #endif
 #ifdef FEAT_FOLDING
     , WV_FDC
+    , WV_FSL
     , WV_FEN
     , WV_FDI
     , WV_FDL

--- a/src/option.h
+++ b/src/option.h
@@ -457,6 +457,7 @@ EXTERN char_u	*p_ffs;		/* 'fileformats' */
 EXTERN char_u	*p_fcl;		/* 'foldclose' */
 EXTERN long	p_fdls;		/* 'foldlevelstart' */
 EXTERN char_u	*p_fdo;		/* 'foldopen' */
+EXTERN char_u	*p_fds;		/* 'foldchars' */
 EXTERN unsigned	fdo_flags;
 # ifdef IN_OPTION_C
 static char *(p_fdo_values[]) = {"all", "block", "hor", "mark", "percent",

--- a/src/screen.c
+++ b/src/screen.c
@@ -120,7 +120,8 @@ static void win_update __ARGS((win_T *wp));
 static void win_draw_end __ARGS((win_T *wp, int c1, int c2, int row, int endrow, hlf_T hl));
 #ifdef FEAT_FOLDING
 static void fold_line __ARGS((win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T lnum, int row));
-static void fill_foldcolumn __ARGS((char_u *p, win_T *wp, int closed, linenr_T lnum));
+static int fill_foldcolumn __ARGS((char_u *p, win_T *wp, int closed, linenr_T lnum));
+static void copy_mbyte_text __ARGS((win_T *wp, int off, int *col, char_u *text));
 static void copy_text_attr __ARGS((int off, char_u *buf, int len, int attr));
 #endif
 static int win_line __ARGS((win_T *, linenr_T, int, int, int nochange));
@@ -2253,22 +2254,32 @@ fold_line(wp, fold_count, foldinfo, lnum, row)
 	fdc = W_WIDTH(wp) - col;
     if (fdc > 0)
     {
-	fill_foldcolumn(buf, wp, TRUE, lnum);
-#ifdef FEAT_RIGHTLEFT
-	if (wp->w_p_rl)
-	{
-	    int		i;
-
-	    copy_text_attr(off + W_WIDTH(wp) - fdc - col, buf, fdc,
-							     hl_attr(HLF_FC));
-	    /* reverse the fold column */
-	    for (i = 0; i < fdc; ++i)
-		ScreenLines[off + W_WIDTH(wp) - i - 1 - col] = buf[i];
-	}
-	else
+	len = fill_foldcolumn(buf, wp, TRUE, lnum);
+        buf[len] = NUL;
+#ifdef FEAT_MBYTE
+        if (has_mbyte)
+        {
+            copy_mbyte_text(wp, off, &col, buf);
+        }
+        else
 #endif
-	    copy_text_attr(off + col, buf, fdc, hl_attr(HLF_FC));
-	col += fdc;
+        {
+#ifdef FEAT_RIGHTLEFT
+            if (wp->w_p_rl)
+            {
+                int		i;
+
+                copy_text_attr(off + W_WIDTH(wp) - len - col, buf, len,
+                                                                 hl_attr(HLF_FC));
+                /* reverse the fold column */
+                for (i = 0; i < len; ++i)
+                    ScreenLines[off + W_WIDTH(wp) - i - 1 - col] = buf[i];
+            }
+            else
+#endif
+                copy_text_attr(off + col, buf, len, hl_attr(HLF_FC));
+            col += len;
+        }
     }
 
 #ifdef FEAT_RIGHTLEFT
@@ -2366,107 +2377,7 @@ fold_line(wp, fold_count, foldinfo, lnum, row)
 #ifdef FEAT_MBYTE
     if (has_mbyte)
     {
-	int	cells;
-	int	u8c, u8cc[MAX_MCO];
-	int	i;
-	int	idx;
-	int	c_len;
-	char_u	*p;
-# ifdef FEAT_ARABIC
-	int	prev_c = 0;		/* previous Arabic character */
-	int	prev_c1 = 0;		/* first composing char for prev_c */
-# endif
-
-# ifdef FEAT_RIGHTLEFT
-	if (wp->w_p_rl)
-	    idx = off;
-	else
-# endif
-	    idx = off + col;
-
-	/* Store multibyte characters in ScreenLines[] et al. correctly. */
-	for (p = text; *p != NUL; )
-	{
-	    cells = (*mb_ptr2cells)(p);
-	    c_len = (*mb_ptr2len)(p);
-	    if (col + cells > W_WIDTH(wp)
-# ifdef FEAT_RIGHTLEFT
-		    - (wp->w_p_rl ? col : 0)
-# endif
-		    )
-		break;
-	    ScreenLines[idx] = *p;
-	    if (enc_utf8)
-	    {
-		u8c = utfc_ptr2char(p, u8cc);
-		if (*p < 0x80 && u8cc[0] == 0)
-		{
-		    ScreenLinesUC[idx] = 0;
-#ifdef FEAT_ARABIC
-		    prev_c = u8c;
-#endif
-		}
-		else
-		{
-#ifdef FEAT_ARABIC
-		    if (p_arshape && !p_tbidi && ARABIC_CHAR(u8c))
-		    {
-			/* Do Arabic shaping. */
-			int	pc, pc1, nc;
-			int	pcc[MAX_MCO];
-			int	firstbyte = *p;
-
-			/* The idea of what is the previous and next
-			 * character depends on 'rightleft'. */
-			if (wp->w_p_rl)
-			{
-			    pc = prev_c;
-			    pc1 = prev_c1;
-			    nc = utf_ptr2char(p + c_len);
-			    prev_c1 = u8cc[0];
-			}
-			else
-			{
-			    pc = utfc_ptr2char(p + c_len, pcc);
-			    nc = prev_c;
-			    pc1 = pcc[0];
-			}
-			prev_c = u8c;
-
-			u8c = arabic_shape(u8c, &firstbyte, &u8cc[0],
-								 pc, pc1, nc);
-			ScreenLines[idx] = firstbyte;
-		    }
-		    else
-			prev_c = u8c;
-#endif
-		    /* Non-BMP character: display as ? or fullwidth ?. */
-#ifdef UNICODE16
-		    if (u8c >= 0x10000)
-			ScreenLinesUC[idx] = (cells == 2) ? 0xff1f : (int)'?';
-		    else
-#endif
-			ScreenLinesUC[idx] = u8c;
-		    for (i = 0; i < Screen_mco; ++i)
-		    {
-			ScreenLinesC[i][idx] = u8cc[i];
-			if (u8cc[i] == 0)
-			    break;
-		    }
-		}
-		if (cells > 1)
-		    ScreenLines[idx + 1] = 0;
-	    }
-	    else if (enc_dbcs == DBCS_JPNU && *p == 0x8e)
-		/* double-byte single width character */
-		ScreenLines2[idx] = p[1];
-	    else if (cells > 1)
-		/* double-width character */
-		ScreenLines[idx + 1] = p[1];
-	    col += cells;
-	    idx += cells;
-	    p += c_len;
-	}
+        copy_mbyte_text(wp, off, &col, text);
     }
     else
 #endif
@@ -2603,6 +2514,120 @@ fold_line(wp, fold_count, foldinfo, lnum, row)
 }
 
 /*
+ * Copy a multi-byte "text" to ScreenLines["off"]. Notice that text is expected
+ * to have a NUL terminator.
+ */
+    static void
+copy_mbyte_text(wp, off, col, text)
+    win_T   *wp;
+    int     off;
+    int     *col;
+    char_u  *text;
+{
+    int	    cells;
+    int	    u8c, u8cc[MAX_MCO];
+    int	    i;
+    int	    idx;
+    int	    c_len;
+    char_u  *p;
+# ifdef FEAT_ARABIC
+    int	    prev_c = 0;		/* previous Arabic character */
+    int	    prev_c1 = 0;	/* first composing char for prev_c */
+# endif
+
+# ifdef FEAT_RIGHTLEFT
+    if (wp->w_p_rl)
+        idx = off;
+    else
+# endif
+        idx = off + *col;
+
+    /* Store multibyte characters in ScreenLines[] et al. correctly. */
+    for (p = text; *p != NUL; )
+    {
+        cells = (*mb_ptr2cells)(p);
+        c_len = (*mb_ptr2len)(p);
+        if (*col + cells > W_WIDTH(wp)
+# ifdef FEAT_RIGHTLEFT
+                - (wp->w_p_rl ? *col : 0)
+# endif
+                )
+            break;
+        ScreenLines[idx] = *p;
+        if (enc_utf8)
+        {
+            u8c = utfc_ptr2char(p, u8cc);
+            if (*p < 0x80 && u8cc[0] == 0)
+            {
+                ScreenLinesUC[idx] = 0;
+#ifdef FEAT_ARABIC
+                prev_c = u8c;
+#endif
+            }
+            else
+            {
+#ifdef FEAT_ARABIC
+                if (p_arshape && !p_tbidi && ARABIC_CHAR(u8c))
+                {
+                    /* Do Arabic shaping. */
+                    int	pc, pc1, nc;
+                    int	pcc[MAX_MCO];
+                    int	firstbyte = *p;
+
+                    /* The idea of what is the previous and next
+                     * character depends on 'rightleft'. */
+                    if (wp->w_p_rl)
+                    {
+                        pc = prev_c;
+                        pc1 = prev_c1;
+                        nc = utf_ptr2char(p + c_len);
+                        prev_c1 = u8cc[0];
+                    }
+                    else
+                    {
+                        pc = utfc_ptr2char(p + c_len, pcc);
+                        nc = prev_c;
+                        pc1 = pcc[0];
+                    }
+                    prev_c = u8c;
+
+                    u8c = arabic_shape(u8c, &firstbyte, &u8cc[0],
+                                                             pc, pc1, nc);
+                    ScreenLines[idx] = firstbyte;
+                }
+                else
+                    prev_c = u8c;
+#endif
+                /* Non-BMP character: display as ? or fullwidth ?. */
+#ifdef UNICODE16
+                if (u8c >= 0x10000)
+                    ScreenLinesUC[idx] = (cells == 2) ? 0xff1f : (int)'?';
+                else
+#endif
+                    ScreenLinesUC[idx] = u8c;
+                for (i = 0; i < Screen_mco; ++i)
+                {
+                    ScreenLinesC[i][idx] = u8cc[i];
+                    if (u8cc[i] == 0)
+                        break;
+                }
+            }
+            if (cells > 1)
+                ScreenLines[idx + 1] = 0;
+        }
+        else if (enc_dbcs == DBCS_JPNU && *p == 0x8e)
+            /* double-byte single width character */
+            ScreenLines2[idx] = p[1];
+        else if (cells > 1)
+            /* double-width character */
+            ScreenLines[idx + 1] = p[1];
+        *col += cells;
+        idx += cells;
+        p += c_len;
+    }
+}
+
+/*
  * Copy "buf[len]" to ScreenLines["off"] and set attributes to "attr".
  */
     static void
@@ -2627,7 +2652,7 @@ copy_text_attr(off, buf, len, attr)
  * Fill the foldcolumn at "p" for window "wp".
  * Only to be called when 'foldcolumn' > 0.
  */
-    static void
+    static int
 fill_foldcolumn(p, wp, closed, lnum)
     char_u	*p;
     win_T	*wp;
@@ -2638,9 +2663,9 @@ fill_foldcolumn(p, wp, closed, lnum)
     int		level;
     int		first_level;
     int		empty;
-
-    /* Init to all spaces. */
-    copy_spaces(p, (size_t)wp->w_p_fdc);
+    int         charsLeft = wp->w_p_fdc;
+    int         bytesWritten = 0;
+    int         bytesPending = 0;
 
     level = win_foldinfo.fi_level;
     if (level > 0)
@@ -2656,21 +2681,57 @@ fill_foldcolumn(p, wp, closed, lnum)
 
 	for (i = 0; i + empty < wp->w_p_fdc; ++i)
 	{
+            bytesPending = 0;
 	    if (win_foldinfo.fi_lnum == lnum
 			      && first_level + i >= win_foldinfo.fi_low_level)
-		p[i] = '-';
+            {
+                bytesPending = (*mb_char2bytes)(fds_fo, p + bytesWritten);
+                --charsLeft;
+            }
             else if (first_level == 1 || !wp->w_p_fsl)
-                p[i] = '|';
+            {
+                bytesPending = (*mb_char2bytes)(fds_fa, p + bytesWritten);
+                --charsLeft;
+            }
             else if (first_level + i <= 9)
+            {
                 p[i] = '0' + first_level + i;
+                ++bytesPending;
+                --charsLeft;
+            }
             else
+            {
                 p[i] = '>';
+                ++bytesPending;
+                --charsLeft;
+            }
+
+            bytesWritten += bytesPending;
+
 	    if (first_level + i == level)
 		break;
 	}
     }
     if (closed)
-	p[i >= wp->w_p_fdc ? i - 1 : i] = '+';
+    {
+        if (bytesPending)
+        {
+           ++charsLeft;
+           bytesWritten -= bytesPending;
+        }
+        bytesWritten += (*mb_char2bytes)(fds_fc, p + bytesWritten);
+        --charsLeft;
+        //p[i >= wp->w_p_fdc ? i - 1 : i] = fds_fc;
+    }
+
+    /* Fill the rest of position on FDC with spaces */
+    if (charsLeft > 0)
+    {
+        copy_spaces(p + bytesWritten, (size_t)charsLeft);
+        bytesWritten += charsLeft;
+    }
+
+    return bytesWritten;
 }
 #endif /* FEAT_FOLDING */
 
@@ -3406,8 +3467,9 @@ win_line(wp, lnum, startrow, endrow, nochange)
 		if (wp->w_p_fdc > 0)
 		{
 		    /* Draw the 'foldcolumn'. */
-		    fill_foldcolumn(extra, wp, FALSE, lnum);
-		    n_extra = wp->w_p_fdc;
+                    n_extra = fill_foldcolumn(extra, wp, FALSE, lnum);
+                    if (n_extra < wp->w_p_fdc)
+                        n_extra = wp->w_p_fdc;
 		    p_extra = extra;
 		    p_extra[n_extra] = NUL;
 		    c_extra = NUL;

--- a/src/screen.c
+++ b/src/screen.c
@@ -2659,12 +2659,12 @@ fill_foldcolumn(p, wp, closed, lnum)
 	    if (win_foldinfo.fi_lnum == lnum
 			      && first_level + i >= win_foldinfo.fi_low_level)
 		p[i] = '-';
-	    else if (first_level == 1)
-		p[i] = '|';
-	    else if (first_level + i <= 9)
-		p[i] = '0' + first_level + i;
-	    else
-		p[i] = '>';
+            else if (first_level == 1 || !wp->w_p_fsl)
+                p[i] = '|';
+            else if (first_level + i <= 9)
+                p[i] = '0' + first_level + i;
+            else
+                p[i] = '>';
 	    if (first_level + i == level)
 		break;
 	}

--- a/src/structs.h
+++ b/src/structs.h
@@ -140,6 +140,8 @@ typedef struct
 #ifdef FEAT_FOLDING
     long	wo_fdc;
 # define w_p_fdc w_onebuf_opt.wo_fdc	/* 'foldcolumn' */
+    int		wo_fsl;
+# define w_p_fsl w_onebuf_opt.wo_fsl	/* 'foldcolshowlvl' */
     int		wo_fen;
 # define w_p_fen w_onebuf_opt.wo_fen	/* 'foldenable' */
     char_u	*wo_fdi;


### PR DESCRIPTION
I added two options to allow user to configure the way they want their fold column.

The first one is to not print the number representing the fold level which is very annoying when you have foldcolumn=1 or 2.

The second one is to define which characters are used to represent the fold column.

The combination of both can give me the image attached:

![vim_folds](https://f.cloud.github.com/assets/1261/164701/0780ad5a-78d7-11e2-94e5-ab63ca7235a6.jpg)
