### PR TITLE
Don't double-encode URLs before parsing them

### DIFF
--- a/src/MacVim/MMAppController.m
+++ b/src/MacVim/MMAppController.m
@@ -1659,12 +1659,9 @@ fsEventCallback(ConstFSEventStreamRef streamRef,
 - (void)handleGetURLEvent:(NSAppleEventDescriptor *)event
                replyEvent:(NSAppleEventDescriptor *)reply
 {
-    NSString *urlString = [[event paramDescriptorForKeyword:keyDirectObject]
-        stringValue];
-    // NOTE: URLWithString requires string to be percent escaped.
-    urlString = [urlString stringByAddingPercentEscapesUsingEncoding:
-                                                        NSUTF8StringEncoding];
-    NSURL *url = [NSURL URLWithString:urlString];
+    NSURL *url = [NSURL URLWithString:[[event
+                                        paramDescriptorForKeyword:keyDirectObject]
+                                        stringValue]];
 
     // We try to be compatible with TextMate's URL scheme here, as documented
     // at http://blog.macromates.com/2007/the-textmate-url-scheme/ . Currently,


### PR DESCRIPTION
#7 ([316](https://code.google.com/p/macvim/issues/detail?id=316)) wasn't a bug. When someone constructs a `mvim:` URL, they _should_ end up escaping the unsafe characters in the path twice: once for the `file:` URL (e.g. `file://Users/steve/foo%20bar/baz.txt`) and again for the `mvim:` URL.

Escaping the whole thing inside MacVim, like this fix did, breaks legit URLs. Here's an example in Python:

``` python
import urllib, webbrowser
url = "mvim://open?" + urllib.urlencode({
    "url": "file://" + urllib.pathname2url('/Users/steve/foo bar/baz.txt')
})
print(url) # -> mvim://open?url=file%3A%2F%2F%2FUsers%2Fsidney%2Ffoo%2520bar%2Fbaz.txt
webbrowser.open(url) # Should work, currently fails
```

In ObjC, the slashes and colon aren't escaped (equally valid as what Python does) but the space does get correctly double-escaped, so same breakage:

``` objective-c
NSLog(@"mvim://open?url=%@", [
    [[NSURL fileURLWithPath:@"/Users/sidney/foo bar/baz.txt"] absoluteString]
    stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding
]); // -> mvim://open?url=file://localhost/Users/sidney/foo%2520bar/baz.txt
```
