### PR TITLE
Use “inoremap” for <M-BS> and <D-BS>

### DIFF
--- a/src/MacVim/gvimrc
+++ b/src/MacVim/gvimrc
@@ -55,13 +55,13 @@ if !exists("macvim_skip_cmd_opt_movement")
 
   no   <D-Up>         <C-Home>
   ino  <D-Up>         <C-Home>
-  map  <M-Up>         {
-  imap <M-Up>         <C-o>{
+  no   <M-Up>         {
+  ino  <M-Up>         <C-o>{
 
   no   <D-Down>       <C-End>
   ino  <D-Down>       <C-End>
-  map  <M-Down>       }
-  imap <M-Down>       <C-o>}
+  no   <M-Down>       }
+  ino  <M-Down>       <C-o>}
 
   ino  <M-BS>         <C-w>
   ino  <D-BS>         <C-u>

--- a/src/MacVim/gvimrc
+++ b/src/MacVim/gvimrc
@@ -63,8 +63,8 @@ if !exists("macvim_skip_cmd_opt_movement")
   map  <M-Down>       }
   imap <M-Down>       <C-o>}
 
-  imap <M-BS>         <C-w>
-  imap <D-BS>         <C-u>
+  ino  <M-BS>         <C-w>
+  ino  <D-BS>         <C-u>
 endif " !exists("macvim_skip_cmd_opt_movement")
 
 


### PR DESCRIPTION
As a Mac user I’m used to using Option-Delete to delete to the beginning of the previous word; MacVim sets up this behavior with its gvimrc. But I also like to use Control-W to delete to the beginning of the line. This change makes it possible for these two mappings to coexist without a problem.
