### PR TITLE
Fix 10.9 Ruby.framework detection/compilation

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -7228,7 +7228,7 @@ echo "${ECHO_T}$rubyhdrdir" >&6; }
 	  RUBY_LIBS="$RUBY_LIBS -L$rubylibdir"
         elif test -d "/System/Library/Frameworks/Ruby.framework"; then
                         RUBY_LIBS="-framework Ruby"
-                        RUBY_CFLAGS=
+                        RUBY_CFLAGS="-DRUBY_VERSION=$rubyversion"
             librubyarg=
 	fi
 

--- a/src/configure.in
+++ b/src/configure.in
@@ -1734,7 +1734,7 @@ if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
             dnl On Mac OS X it is safer to just use the -framework flag
             RUBY_LIBS="-framework Ruby"
             dnl Don't include the -I flag when -framework is set
-            RUBY_CFLAGS=
+            RUBY_CFLAGS="-DRUBY_VERSION=$rubyversion"
             librubyarg=
 	fi
 

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -102,7 +102,11 @@
 # include <ruby.h>
 #endif
 #ifdef RUBY19_OR_LATER
-# include <ruby/encoding.h>
+# ifdef FEAT_GUI_MACVIM
+#  include <Ruby/ruby/encoding.h>
+# else
+#  include <ruby/encoding.h>
+# endif
 #endif
 
 #undef off_t	/* ruby defines off_t as _int64, Mingw uses long */


### PR DESCRIPTION
Mac OS X Mavericks ships with Ruby.framework 2.0 which requires some fixes to enable proper header inclusion and version defines.

This is a stripped down version of the homebrew formula patches at felixbuenemann/homebrew@81824e31564538e9df4d0552cf5063691f17c688.
In comparison to the homebrew patches it only allows compilation against the current Ruby.framework (1.8 on pre-10.9, 2.0 on 10.9).

While the more extended patch for homebrew allows to compile against 1.8 framework on Mavericks, I chose to go with this simpler version because I don't think it makes much sense to link against an ancient unsupported ruby version.
