### PR TITLE
Fix getfontname().

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -991,7 +991,7 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
 {
     NSString *fontName = (NSString *)font;
     float size = 0;
-    NSArray *components = [fontName componentsSeparatedByString:@":"];
+    NSArray *components = [fontName componentsSeparatedByString:@":h"];
     if ([components count] == 2) {
         size = [[components lastObject] floatValue];
         fontName = [components objectAtIndex:0];

--- a/src/MacVim/gui_macvim.m
+++ b/src/MacVim/gui_macvim.m
@@ -1017,7 +1017,7 @@ gui_mch_set_font(GuiFont font)
 gui_macvim_font_with_name(char_u *name)
 {
     if (!name)
-        return (GuiFont)[[NSString alloc] initWithFormat:@"%@:%d",
+        return (GuiFont)[[NSString alloc] initWithFormat:@"%@:h%d",
                                         MMDefaultFontName, MMDefaultFontSize];
 
     NSString *fontName = [NSString stringWithVimString:name];
@@ -1055,7 +1055,7 @@ gui_macvim_font_with_name(char_u *name)
         // can load it.  Otherwise we ask NSFont if it can load it.
         if ([fontName isEqualToString:MMDefaultFontName]
                 || [NSFont fontWithName:fontName size:size])
-            return [[NSString alloc] initWithFormat:@"%@:%d", fontName, size];
+            return [[NSString alloc] initWithFormat:@"%@:h%d", fontName, size];
     }
 
     return NOFONT;


### PR DESCRIPTION
getfontname() would incorrectly return strings of the form
"FONTNAME:SIZE", when it should be returning strings of the form
"FONTNAME:hSIZE"--notice the "h" in the last form.  However, the
internal font string needs to maintain the first form.  So, instead we
cut it up and insert the "h" in the proper location giving it the proper
form.
