### PR TITLE
JSON is not JavaScript

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -968,7 +968,7 @@ au BufNewFile,BufRead *.java,*.jav		setf java
 au BufNewFile,BufRead *.jj,*.jjt		setf javacc
 
 " JavaScript, ECMAScript
-au BufNewFile,BufRead *.js,*.javascript,*.es,*.jsx,*.json   setf javascript
+au BufNewFile,BufRead *.js,*.javascript,*.es,*.jsx   setf javascript
 
 " Java Server Pages
 au BufNewFile,BufRead *.jsp			setf jsp


### PR DESCRIPTION
JSON is a hyper-strict subset of JavaScript-like syntax. It should not be treated as JS. Treating it as JS breaks all sorts of other plugins for minimum gain, if any.
