### PR TITLE
Using floats fails when using a comma-as-a-decimal-separator locale

### DIFF
--- a/src/os_mac_conv.c
+++ b/src/os_mac_conv.c
@@ -584,6 +584,7 @@ mac_lang_init() {
 	    vim_setenv((char_u *)"LANG", (char_u *)buf);
 #   ifdef HAVE_LOCALE_H
 	    setlocale(LC_ALL, "");
+            setlocale(LC_NUMERIC, "C");
 #   endif
 	}
     }


### PR DESCRIPTION
...the decimal separator is a comma
