### PR TITLE
Use HTTPS for SUFeedURL

### DIFF
--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1278,7 +1278,7 @@
 		</dict>
 	</array>
 	<key>SUFeedURL</key>
-	<string>http://b4winckler.github.com/macvim/appcast/stable.xml</string>
+	<string>https://b4winckler.github.com/macvim/appcast/stable.xml</string>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
 


### PR DESCRIPTION
The use of a HTTP SUFeedURL opens the user up
to a RCE vulnerability by MiTM attacks when the
update feed is fetched.

See: https://vulnsec.com/2016/osx-apps-vulnerabilities/
